### PR TITLE
feat: Add an initial implementation of a minimal TLD-operator

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,5 +50,19 @@ jobs:
           echo "Calling runTests on canister cns_root_test..."
           dfx canister call cns_root_test runTests "()"
 
+      - name: 'Test tld_operator canister'
+        run: |
+          dfx deploy --no-wallet tld_operator_test
+          echo "Adding tld_operator_test-canister as a controller of tld_operator-canister..."
+          dfx canister update-settings tld_operator --add-controller `dfx canister id tld_operator_test`
+          echo "Calling runTests on canister tld_operator_test..."
+          dfx canister call tld_operator_test runTests "()"
+
+      - name: 'Test tld_operator canister if not controller'
+        run: |
+          dfx deploy --no-wallet tld_operator_test_not_controller
+          echo "Calling runTestsIfNotController on canister tld_operator_test_not_controller..."
+          dfx canister call tld_operator_test_not_controller runTestsIfNotController "()"
+
       - name: 'Stop DFX'
         run: dfx stop

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,6 +59,9 @@ jobs:
           dfx canister call tld_operator_test runTests "()"
 
       - name: 'Test tld_operator canister if not controller'
+        # NOTE: the canister tld_operator_test_not_controller uses the same WASM as tld_operator_test,
+        #   but it is used to test a different behaviour, namely that tld_operator-canister does not
+        #   accept certain calls when the caller is not a controller of tld_operator-canister.
         run: |
           dfx deploy --no-wallet tld_operator_test_not_controller
           echo "Calling runTestsIfNotController on canister tld_operator_test_not_controller..."

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ dist
 
 ## IDEs
 .idea/
+
+.mops

--- a/dfx.json
+++ b/dfx.json
@@ -4,39 +4,27 @@
     "cns_root": {
       "main": "minimal_cns/src/backend/cns_root.mo",
       "type": "motoko",
-      "dependencies": [
-        "name_registry"
-      ]
+      "dependencies": ["name_registry"]
     },
     "cns_root_test": {
       "main": "minimal_cns/src/backend/cns_root.test.mo",
       "type": "motoko",
-      "dependencies": [
-        "cns_root"
-      ]
+      "dependencies": ["cns_root"]
     },
     "tld_operator": {
       "main": "minimal_cns/src/backend/tld_operator.mo",
       "type": "motoko",
-      "dependencies": [
-        "name_registry"
-      ]
+      "dependencies": ["name_registry"]
     },
     "tld_operator_test": {
       "main": "minimal_cns/src/backend/tld_operator.test.mo",
       "type": "motoko",
-      "dependencies": [
-        "name_registry",
-        "tld_operator"
-      ]
+      "dependencies": ["name_registry", "tld_operator"]
     },
     "tld_operator_test_not_controller": {
       "main": "minimal_cns/src/backend/tld_operator.test.mo",
       "type": "motoko",
-      "dependencies": [
-        "name_registry",
-        "tld_operator"
-      ]
+      "dependencies": ["name_registry", "tld_operator"]
     },
     "name_registry": {
       "type": "rust",

--- a/dfx.json
+++ b/dfx.json
@@ -1,15 +1,42 @@
 {
-  "dfx": "0.24.2",
+  "dfx": "0.24.3",
   "canisters": {
     "cns_root": {
       "main": "minimal_cns/src/backend/cns_root.mo",
       "type": "motoko",
-      "dependencies": ["name_registry"]
+      "dependencies": [
+        "name_registry"
+      ]
     },
     "cns_root_test": {
       "main": "minimal_cns/src/backend/cns_root.test.mo",
       "type": "motoko",
-      "dependencies": ["cns_root"]
+      "dependencies": [
+        "cns_root"
+      ]
+    },
+    "tld_operator": {
+      "main": "minimal_cns/src/backend/tld_operator.mo",
+      "type": "motoko",
+      "dependencies": [
+        "name_registry"
+      ]
+    },
+    "tld_operator_test": {
+      "main": "minimal_cns/src/backend/tld_operator.test.mo",
+      "type": "motoko",
+      "dependencies": [
+        "name_registry",
+        "tld_operator"
+      ]
+    },
+    "tld_operator_test_not_controller": {
+      "main": "minimal_cns/src/backend/tld_operator.test.mo",
+      "type": "motoko",
+      "dependencies": [
+        "name_registry",
+        "tld_operator"
+      ]
     },
     "name_registry": {
       "type": "rust",

--- a/minimal_cns/src/backend/tld_operator.mo
+++ b/minimal_cns/src/backend/tld_operator.mo
@@ -1,0 +1,135 @@
+import NameRegistry "canister:name_registry";
+import Text "mo:base/Text";
+import Map "mo:base/OrderedMap";
+import Principal "mo:base/Principal";
+import Debug "mo:base/Debug";
+
+actor TldOperator {
+  let myTld = ".icp";
+  type DomainRecord = NameRegistry.DomainRecord;
+  type DomainLookup = NameRegistry.DomainLookup;
+
+  type OperationResult = {
+    success : Bool;
+    message : ?Text;
+  };
+
+  type RegisterResult = OperationResult;
+
+  type RegistrationControllerRole = {
+    #registrar;
+    #registrant;
+    #technical;
+    #administrative;
+  };
+
+  type RegistrationController = {
+    principal : Principal;
+    roles : [RegistrationControllerRole];
+  };
+
+  /*
+  // Types related to domain registration, but not used by `register`-endpoint.
+  type DomainRegistrationStatus = { #active; #inactive; #transfer_prohibited };
+  type RegistrationEventAction = {
+    #registration;
+    #locked;
+    #unlocked;
+    #expiration;
+    #reregistration;
+    #transfer;
+  };
+
+  type RegistrationEvent = {
+    action : RegistrationEventAction;
+    date : Text;
+  };
+  type DomainRegistrationData = {
+    name : Text;
+    status : [DomainRegistrationStatus];
+    events : [RegistrationEvent];
+    entities : [RegistrationController];
+    name_canister : ?Principal;
+  };
+
+  type RegistrationDataResult = {
+    certificate : Blob;
+    data : DomainRegistrationData;
+  };
+  */
+
+  type RegistrationRecords = {
+    controller : [RegistrationController];
+    records : ?[DomainRecord];
+  };
+
+  type DomainRecordsMap = Map.Map<Text, DomainRecord>;
+  let answersWrapper = Map.Make<Text>(Text.compare);
+  stable var lookupAnswersMap : DomainRecordsMap = answersWrapper.empty();
+
+  public shared query func lookup(domain : Text, recordType : Text) : async DomainLookup {
+    var answers : [DomainRecord] = [];
+    let domainLowercase : Text = Text.toLowercase(domain);
+
+    if (Text.endsWith(domainLowercase, #text myTld)) {
+      switch (Text.toUppercase(recordType)) {
+        case ("CID") {
+          let maybeAnswer : ?DomainRecord = answersWrapper.get(lookupAnswersMap, domainLowercase);
+          answers := switch maybeAnswer {
+            case null { [] };
+            case (?answer) { [answer] };
+          };
+        };
+        case _ {};
+      };
+    };
+
+    {
+      answers = answers;
+      additionals = [];
+      authorities = [];
+    };
+  };
+
+  public shared ({ caller }) func register(domain : Text, records : RegistrationRecords) : async (RegisterResult) {
+    if (not Principal.isController(caller)) {
+      return {
+        success = false;
+        message = ?("Currently only a canister controller can register " # myTld # "-domains, caller: " # Principal.toText(caller));
+      };
+    };
+    let domainRecords = switch (records.records) {
+      case (null) { [] };
+      case (?records) { records };
+    };
+    // TODO: remove the restriction of acceping exactly one domain record.
+    if (domainRecords.size() != 1) {
+      return {
+        success = false;
+        message = ?"Currently exactly one domain record must be specified.";
+      };
+    };
+    let record : DomainRecord = domainRecords[0];
+    let domainLowercase : Text = Text.toLowercase(domain);
+    if (not Text.endsWith(domainLowercase, #text myTld)) {
+      return {
+        success = false;
+        message = ?("Unsupported TLD in domain " # domain # ", expected TLD=" #myTld);
+      };
+    };
+    if (domainLowercase != Text.toLowercase(record.name)) {
+      return {
+        success = false;
+        message = ?("Inconsistent domain record, record.name: `" # domain # "` doesn't match domain: " # domainLowercase);
+      };
+    };
+    // TODO: add more checks: validate domain name and all the fields of the domain record(s).
+
+    lookupAnswersMap := answersWrapper.put(lookupAnswersMap, domainLowercase, record);
+
+    return {
+      success = true;
+      message = null;
+    };
+  };
+};

--- a/minimal_cns/src/backend/tld_operator.test.mo
+++ b/minimal_cns/src/backend/tld_operator.test.mo
@@ -1,0 +1,171 @@
+import NameRegistry "canister:name_registry";
+import IcpTldOperator "canister:tld_operator";
+import Debug "mo:base/Debug";
+import Option "mo:base/Option";
+import Text "mo:base/Text";
+
+actor {
+  type DomainRecord = NameRegistry.DomainRecord;
+
+  public func runTests() : async () {
+    await shouldNotLookupNonregisteredIcpDomain();
+    await shouldRegisterAndLookupIcpDomain();
+    await shouldNotRegisterNonIcpDomain();
+    await shouldNotRegisterIfInconsistentDomainRecord();
+  };
+
+  public func runTestsIfNotController() : async () {
+    await shouldNotRegisterDomainIfNotController();
+  };
+
+  func as_text(maybe_text : ?Text) : Text {
+    return Option.get(maybe_text, "");
+  };
+
+  func is_eq_int(actual : Int, expected : Int, errMsg : ?Text) : Bool {
+    let is_eq = actual == expected;
+    if (not is_eq) {
+      Debug.print("Values not equal: actual " # debug_show (actual) # ", expected: " # debug_show (expected) # "; error: " # as_text(errMsg));
+    };
+    return is_eq;
+  };
+
+  func msg_has_substr(msg : Text, substr : Text, errMsg : ?Text) : Bool {
+    let has_substr = Text.contains(msg, #text substr);
+    if (not has_substr) {
+      Debug.print("Expected substing '" # substr # "' not found in message '" # msg # "', error: " # as_text(errMsg));
+    };
+    return has_substr;
+  };
+
+  func is_true(actual : Bool, errMsg : ?Text) : Bool {
+    if (not actual) {
+      Debug.print("Unexpected false value, error: " # as_text(errMsg));
+    };
+    return actual;
+  };
+
+  func shouldNotLookupNonregisteredIcpDomain() : async () {
+    for (
+      (domain, recordType) in [
+        ("first.example.icp", "CID"),
+        ("another.example.ICP", "CID"),
+        ("other.domain.com", "CID"),
+      ].vals()
+    ) {
+      let response = await IcpTldOperator.lookup(domain, recordType);
+      let errMsg = ?("shouldNotLookupNonregisteredIcpDomain() failed for domain: " # domain # ", recordType: " # recordType);
+      assert is_eq_int(response.answers.size(), 0, errMsg);
+      assert is_eq_int(response.additionals.size(), 0, errMsg);
+      assert is_eq_int(response.authorities.size(), 0, errMsg);
+    };
+  };
+
+  func shouldRegisterAndLookupIcpDomain() : async () {
+    for (
+      (domain, recordType) in [
+        ("my_domain.icp", "CID"),
+        ("example.icp", "Cid"),
+        ("another.ICP", "cid"),
+        ("one.more.Icp", "CId"),
+      ].vals()
+    ) {
+      let domainRecord : DomainRecord = {
+        name = domain;
+        record_type = "CID";
+        ttl = 3600;
+        data = "aaa-aaaa";
+      };
+      let registrationRecords = {
+        controller = [];
+        records = ?[domainRecord];
+      };
+      let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+      assert is_true(registerResponse.success, registerResponse.message);
+
+      let lookupResponse = await IcpTldOperator.lookup(domain, recordType);
+      let errMsg = ?("shouldRegisterAndLookupIcpDomain() failed for domain: " # domain # ", recordType: " # recordType);
+      assert is_eq_int(lookupResponse.answers.size(), 1, errMsg);
+      assert is_eq_int(lookupResponse.additionals.size(), 0, errMsg);
+      assert is_eq_int(lookupResponse.authorities.size(), 0, errMsg);
+
+      let responseDomainRecord = lookupResponse.answers[0];
+      assert (responseDomainRecord == domainRecord);
+    };
+  };
+
+  func shouldNotRegisterNonIcpDomain() : async () {
+    for (
+      (domain) in [
+        (".fun"),
+        ("example.com"),
+        ("another.dfn"),
+        (""),
+        ("one.more.dfn"),
+      ].vals()
+    ) {
+      let domainRecord : DomainRecord = {
+        name = domain;
+        record_type = "CID";
+        ttl = 3600;
+        data = "aaa-aaaa";
+      };
+      let registrationRecords = {
+        controller = [];
+        records = ?[domainRecord];
+      };
+      let response = await IcpTldOperator.register(domain, registrationRecords);
+      let errMsg = ?("shouldNotRegisterNonIcpDomain() failed for domain: " # domain);
+      assert is_true(not response.success, errMsg);
+    };
+  };
+
+  func shouldNotRegisterIfInconsistentDomainRecord() : async () {
+    for (
+      (domain, record_name) in [
+        ("some.name.icp", "other.domain.icp"),
+        ("valid.subdomain.icp", "subdomain.icp"),
+      ].vals()
+    ) {
+      let domainRecord : DomainRecord = {
+        name = record_name;
+        record_type = "CID";
+        ttl = 3600;
+        data = "aaa-aaaa";
+      };
+      let registrationRecords = {
+        controller = [];
+        records = ?[domainRecord];
+      };
+      let response = await IcpTldOperator.register(domain, registrationRecords);
+      let errMsg = ?("shouldNotRegisterIfInconsistentDomainRecord() failed for domain: " # domain);
+      assert is_true(not response.success, errMsg);
+      assert msg_has_substr(as_text(response.message), "Inconsistent domain record", errMsg);
+    };
+  };
+
+  func shouldNotRegisterDomainIfNotController() : async () {
+    for (
+      (domain) in [
+        ("my_domain.icp"),
+        ("example.icp"),
+      ].vals()
+    ) {
+      let domainRecord : DomainRecord = {
+        name = domain;
+        record_type = "CID";
+        ttl = 3600;
+        data = "aaa-aaaa";
+      };
+      let registrationRecords = {
+        controller = [];
+        records = ?[domainRecord];
+      };
+      let response = await IcpTldOperator.register(domain, registrationRecords);
+      let errMsg = ?("shouldNotRegisterDomainIfNotController() failed for domain: " # domain);
+      assert is_true(not response.success, errMsg);
+      assert msg_has_substr(as_text(response.message), "only a canister controller can register", errMsg);
+    };
+  };
+
+};

--- a/minimal_cns/src/backend/tld_operator.test.mo
+++ b/minimal_cns/src/backend/tld_operator.test.mo
@@ -18,29 +18,29 @@ actor {
     await shouldNotRegisterDomainIfNotController();
   };
 
-  func as_text(maybe_text : ?Text) : Text {
+  func asText(maybe_text : ?Text) : Text {
     return Option.get(maybe_text, "");
   };
 
-  func is_eq_int(actual : Int, expected : Int, errMsg : ?Text) : Bool {
-    let is_eq = actual == expected;
-    if (not is_eq) {
-      Debug.print("Values not equal: actual " # debug_show (actual) # ", expected: " # debug_show (expected) # "; error: " # as_text(errMsg));
+  func isEqualInt(actual : Int, expected : Int, errMsg : Text) : Bool {
+    let isEq = actual == expected;
+    if (not isEq) {
+      Debug.print("Expected Int: " # debug_show (expected) # ", got: " # debug_show (actual) # "; error: " # errMsg);
     };
-    return is_eq;
+    return isEq;
   };
 
-  func msg_has_substr(msg : Text, substr : Text, errMsg : ?Text) : Bool {
-    let has_substr = Text.contains(msg, #text substr);
-    if (not has_substr) {
-      Debug.print("Expected substing '" # substr # "' not found in message '" # msg # "', error: " # as_text(errMsg));
+  func textContains(text : Text, subText : Text, errMsg : Text) : Bool {
+    let contains = Text.contains(text, #text subText);
+    if (not contains) {
+      Debug.print("Expected text '" # text # "' to contain '" # subText # "', error: " # errMsg);
     };
-    return has_substr;
+    return contains;
   };
 
-  func is_true(actual : Bool, errMsg : ?Text) : Bool {
+  func isTrue(actual : Bool, errMsg : Text) : Bool {
     if (not actual) {
-      Debug.print("Unexpected false value, error: " # as_text(errMsg));
+      Debug.print("Expected Bool to be true, error: " # errMsg);
     };
     return actual;
   };
@@ -54,10 +54,10 @@ actor {
       ].vals()
     ) {
       let response = await IcpTldOperator.lookup(domain, recordType);
-      let errMsg = ?("shouldNotLookupNonregisteredIcpDomain() failed for domain: " # domain # ", recordType: " # recordType);
-      assert is_eq_int(response.answers.size(), 0, errMsg);
-      assert is_eq_int(response.additionals.size(), 0, errMsg);
-      assert is_eq_int(response.authorities.size(), 0, errMsg);
+      let errMsg = "shouldNotLookupNonregisteredIcpDomain() failed for domain: " # domain # ", recordType: " # recordType # ", size of ";
+      assert isEqualInt(response.answers.size(), 0, errMsg # "answers");
+      assert isEqualInt(response.additionals.size(), 0, errMsg # "additionals");
+      assert isEqualInt(response.authorities.size(), 0, errMsg # "authorities");
     };
   };
 
@@ -81,13 +81,13 @@ actor {
         records = ?[domainRecord];
       };
       let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
-      assert is_true(registerResponse.success, registerResponse.message);
+      assert isTrue(registerResponse.success, asText(registerResponse.message));
 
       let lookupResponse = await IcpTldOperator.lookup(domain, recordType);
-      let errMsg = ?("shouldRegisterAndLookupIcpDomain() failed for domain: " # domain # ", recordType: " # recordType);
-      assert is_eq_int(lookupResponse.answers.size(), 1, errMsg);
-      assert is_eq_int(lookupResponse.additionals.size(), 0, errMsg);
-      assert is_eq_int(lookupResponse.authorities.size(), 0, errMsg);
+      let errMsg = "shouldRegisterAndLookupIcpDomain() failed for domain: " # domain # ", recordType: " # recordType # ", size of ";
+      assert isEqualInt(lookupResponse.answers.size(), 1, errMsg # "answers");
+      assert isEqualInt(lookupResponse.additionals.size(), 0, errMsg # "additionals");
+      assert isEqualInt(lookupResponse.authorities.size(), 0, errMsg # "authorities");
 
       let responseDomainRecord = lookupResponse.answers[0];
       assert (responseDomainRecord == domainRecord);
@@ -115,8 +115,8 @@ actor {
         records = ?[domainRecord];
       };
       let response = await IcpTldOperator.register(domain, registrationRecords);
-      let errMsg = ?("shouldNotRegisterNonIcpDomain() failed for domain: " # domain);
-      assert is_true(not response.success, errMsg);
+      let errMsg = "shouldNotRegisterNonIcpDomain() failed for domain: " # domain;
+      assert isTrue(not response.success, errMsg);
     };
   };
 
@@ -138,9 +138,9 @@ actor {
         records = ?[domainRecord];
       };
       let response = await IcpTldOperator.register(domain, registrationRecords);
-      let errMsg = ?("shouldNotRegisterIfInconsistentDomainRecord() failed for domain: " # domain);
-      assert is_true(not response.success, errMsg);
-      assert msg_has_substr(as_text(response.message), "Inconsistent domain record", errMsg);
+      let errMsg = "shouldNotRegisterIfInconsistentDomainRecord() failed for domain: " # domain;
+      assert isTrue(not response.success, errMsg);
+      assert textContains(asText(response.message), "Inconsistent domain record", errMsg);
     };
   };
 
@@ -162,9 +162,9 @@ actor {
         records = ?[domainRecord];
       };
       let response = await IcpTldOperator.register(domain, registrationRecords);
-      let errMsg = ?("shouldNotRegisterDomainIfNotController() failed for domain: " # domain);
-      assert is_true(not response.success, errMsg);
-      assert msg_has_substr(as_text(response.message), "only a canister controller can register", errMsg);
+      let errMsg = "shouldNotRegisterDomainIfNotController() failed for domain: " # domain;
+      assert isTrue(not response.success, errMsg);
+      assert textContains(asText(response.message), "only a canister controller can register", errMsg);
     };
   };
 


### PR DESCRIPTION
Add a Motoko-implementation of a minimal TLD-operator.  This initial implementation has a hard-coded TLD (`.icp`), which will be changed to a configurable init-parameter at a later point. 

TT-511