### PR TITLE
fix: factor out test_utils, clean-up test code

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,10 +64,5 @@ jobs:
           echo "Calling runTests on canister tld_operator_test..."
           dfx canister call tld_operator_test runTests "()"
 
-      - name: 'Test tld_operator canister if not controller'
-
-        run: |
-          dfx deploy --no-wallet tld_operator_test_not_controller
-
       - name: 'Stop DFX'
         run: dfx stop

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -51,21 +51,24 @@ jobs:
           dfx canister call cns_root_test runTests "()"
 
       - name: 'Test tld_operator canister'
+        # NOTE: The functionality of tld_operator depends on whehter the caller is a controller or not,
+        #   so we proceed in two steps.  Initially the test canister (i.e. tld_operator_test) is not a controller,
+        #   so we test the behaviour for non-controller callers.  Afterwards we make the test canister 
+        #   a controller of tld_operator, and test the behaviour for controller callers.
         run: |
           dfx deploy --no-wallet tld_operator_test
+          echo "Calling runTestsIfNotController on canister tld_operator_test ..."
+          dfx canister call tld_operator_test runTestsIfNotController "()"
           echo "Adding tld_operator_test-canister as a controller of tld_operator-canister..."
           dfx canister update-settings tld_operator --add-controller `dfx canister id tld_operator_test`
           echo "Calling runTests on canister tld_operator_test..."
           dfx canister call tld_operator_test runTests "()"
 
       - name: 'Test tld_operator canister if not controller'
-        # NOTE: the canister tld_operator_test_not_controller uses the same WASM as tld_operator_test,
-        #   but it is used to test a different behaviour, namely that tld_operator-canister does not
-        #   accept certain calls when the caller is not a controller of tld_operator-canister.
+
         run: |
           dfx deploy --no-wallet tld_operator_test_not_controller
-          echo "Calling runTestsIfNotController on canister tld_operator_test_not_controller..."
-          dfx canister call tld_operator_test_not_controller runTestsIfNotController "()"
+
 
       - name: 'Stop DFX'
         run: dfx stop

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: 'Test tld_operator canister'
         # NOTE: The functionality of tld_operator depends on whehter the caller is a controller or not,
         #   so we proceed in two steps.  Initially the test canister (i.e. tld_operator_test) is not a controller,
-        #   so we test the behaviour for non-controller callers.  Afterwards we make the test canister 
+        #   so we test the behaviour for non-controller callers.  Afterwards we make the test canister
         #   a controller of tld_operator, and test the behaviour for controller callers.
         run: |
           dfx deploy --no-wallet tld_operator_test
@@ -68,7 +68,6 @@ jobs:
 
         run: |
           dfx deploy --no-wallet tld_operator_test_not_controller
-
 
       - name: 'Stop DFX'
         run: dfx stop

--- a/dfx.json
+++ b/dfx.json
@@ -21,11 +21,6 @@
       "type": "motoko",
       "dependencies": ["name_registry", "tld_operator"]
     },
-    "tld_operator_test_not_controller": {
-      "main": "minimal_cns/src/backend/tld_operator.test.mo",
-      "type": "motoko",
-      "dependencies": ["name_registry", "tld_operator"]
-    },
     "name_registry": {
       "type": "rust",
       "candid": "canisters/name-registry/spec.did",

--- a/minimal_cns/src/backend/cns_root.test.mo
+++ b/minimal_cns/src/backend/cns_root.test.mo
@@ -1,4 +1,5 @@
 import CnsRoot "canister:cns_root";
+import Test "../test_utils"
 
 actor {
   public func runTests() : async () {
@@ -19,14 +20,15 @@ actor {
       ].vals()
     ) {
       let response = await CnsRoot.lookup(domain, recordType);
-      assert (response.answers.size() == 1);
-      assert (response.additionals.size() == 0);
-      assert (response.authorities.size() == 0);
+      let errMsg = "shouldGetIcpTldOperatorForNcIcpLookups() failed for domain: " # domain # ", recordType: " # recordType # "; ";
+      assert Test.isEqualInt(response.answers.size(), 1, errMsg # "size of response.answers");
+      assert Test.isEqualInt(response.additionals.size(), 0, errMsg # "size of response.additionals");
+      assert Test.isEqualInt(response.authorities.size(), 0, errMsg # "size of response.authorities");
       let domainRecord = response.answers[0];
-      assert (domainRecord.name == ".icp.");
-      assert (domainRecord.record_type == "NC");
-      assert (domainRecord.ttl == 3600);
-      assert (domainRecord.data == icpTldCanisterId);
+      assert Test.isEqualText(domainRecord.name, ".icp.", errMsg # "field: DomainRecord.name");
+      assert Test.isEqualText(domainRecord.record_type, "NC", errMsg # "field: DomainRecord.record_type");
+      assert Test.isEqualInt(domainRecord.ttl, 3600, errMsg # "field: DomainRecord.ttl");
+      assert Test.isEqualText(domainRecord.data, icpTldCanisterId, errMsg # "field: DomainRecord.data");
     };
   };
 
@@ -42,14 +44,15 @@ actor {
       ].vals()
     ) {
       let response = await CnsRoot.lookup(domain, recordType);
-      assert (response.answers.size() == 0);
-      assert (response.additionals.size() == 0);
-      assert (response.authorities.size() == 1);
+      let errMsg = "shouldGetIcpTldOperatorForOtherIcpLookups() failed for domain: " # domain # ", recordType: " # recordType # "; ";
+      assert Test.isEqualInt(response.answers.size(), 0, errMsg # "size of response.answers");
+      assert Test.isEqualInt(response.additionals.size(), 0, errMsg # "size of response.additionals");
+      assert Test.isEqualInt(response.authorities.size(), 1, errMsg # "size of response.authorities");
       let domainRecord = response.authorities[0];
-      assert (domainRecord.name == ".icp.");
-      assert (domainRecord.record_type == "NC");
-      assert (domainRecord.ttl == 3600);
-      assert (domainRecord.data == icpTldCanisterId);
+      assert Test.isEqualText(domainRecord.name, ".icp.", errMsg # "field: DomainRecord.name");
+      assert Test.isEqualText(domainRecord.record_type, "NC", errMsg # "field: DomainRecord.record_type");
+      assert Test.isEqualInt(domainRecord.ttl, 3600, errMsg # "field: DomainRecord.ttl");
+      assert Test.isEqualText(domainRecord.data, icpTldCanisterId, errMsg # "field: DomainRecord.data");
     };
   };
 
@@ -64,9 +67,10 @@ actor {
       ].vals()
     ) {
       let response = await CnsRoot.lookup(domain, recordType);
-      assert (response.answers.size() == 0);
-      assert (response.additionals.size() == 0);
-      assert (response.authorities.size() == 0);
+      let errMsg = "shouldNotGetOtherTldOperator() failed for domain: " # domain # ", recordType: " # recordType # "; size of response.";
+      assert Test.isEqualInt(response.answers.size(), 0, errMsg # "answers");
+      assert Test.isEqualInt(response.additionals.size(), 0, errMsg # "additionals");
+      assert Test.isEqualInt(response.authorities.size(), 0, errMsg # "sauthorities");
     };
   };
 

--- a/minimal_cns/src/backend/cns_root.test.mo
+++ b/minimal_cns/src/backend/cns_root.test.mo
@@ -1,4 +1,5 @@
 import CnsRoot "canister:cns_root";
+import Nat32 "mo:base/Nat32";
 import Test "../test_utils"
 
 actor {
@@ -27,7 +28,7 @@ actor {
       let domainRecord = response.answers[0];
       assert Test.isEqualText(domainRecord.name, ".icp.", errMsg # "field: DomainRecord.name");
       assert Test.isEqualText(domainRecord.record_type, "NC", errMsg # "field: DomainRecord.record_type");
-      assert Test.isEqualInt(domainRecord.ttl, 3600, errMsg # "field: DomainRecord.ttl");
+      assert Test.isEqualInt(Nat32.toNat(domainRecord.ttl), 3600, errMsg # "field: DomainRecord.ttl");
       assert Test.isEqualText(domainRecord.data, icpTldCanisterId, errMsg # "field: DomainRecord.data");
     };
   };
@@ -51,7 +52,7 @@ actor {
       let domainRecord = response.authorities[0];
       assert Test.isEqualText(domainRecord.name, ".icp.", errMsg # "field: DomainRecord.name");
       assert Test.isEqualText(domainRecord.record_type, "NC", errMsg # "field: DomainRecord.record_type");
-      assert Test.isEqualInt(domainRecord.ttl, 3600, errMsg # "field: DomainRecord.ttl");
+      assert Test.isEqualInt(Nat32.toNat(domainRecord.ttl), 3600, errMsg # "field: DomainRecord.ttl");
       assert Test.isEqualText(domainRecord.data, icpTldCanisterId, errMsg # "field: DomainRecord.data");
     };
   };

--- a/minimal_cns/src/backend/tld_operator.mo
+++ b/minimal_cns/src/backend/tld_operator.mo
@@ -2,7 +2,6 @@ import NameRegistry "canister:name_registry";
 import Text "mo:base/Text";
 import Map "mo:base/OrderedMap";
 import Principal "mo:base/Principal";
-import Debug "mo:base/Debug";
 
 actor TldOperator {
   let myTld = ".icp";

--- a/minimal_cns/src/backend/tld_operator.test.mo
+++ b/minimal_cns/src/backend/tld_operator.test.mo
@@ -3,6 +3,7 @@ import IcpTldOperator "canister:tld_operator";
 import Debug "mo:base/Debug";
 import Option "mo:base/Option";
 import Text "mo:base/Text";
+import Test "../test_utils"
 
 actor {
   type DomainRecord = NameRegistry.DomainRecord;
@@ -18,31 +19,8 @@ actor {
     await shouldNotRegisterDomainIfNotController();
   };
 
-  func asText(maybe_text : ?Text) : Text {
-    return Option.get(maybe_text, "");
-  };
-
-  func isEqualInt(actual : Int, expected : Int, errMsg : Text) : Bool {
-    let isEq = actual == expected;
-    if (not isEq) {
-      Debug.print("Expected Int: " # debug_show (expected) # ", got: " # debug_show (actual) # "; error: " # errMsg);
-    };
-    return isEq;
-  };
-
-  func textContains(text : Text, subText : Text, errMsg : Text) : Bool {
-    let contains = Text.contains(text, #text subText);
-    if (not contains) {
-      Debug.print("Expected text '" # text # "' to contain '" # subText # "', error: " # errMsg);
-    };
-    return contains;
-  };
-
-  func isTrue(actual : Bool, errMsg : Text) : Bool {
-    if (not actual) {
-      Debug.print("Expected Bool to be true, error: " # errMsg);
-    };
-    return actual;
+  func asText(maybeText : ?Text) : Text {
+    return Option.get(maybeText, "");
   };
 
   func shouldNotLookupNonregisteredIcpDomain() : async () {
@@ -54,10 +32,10 @@ actor {
       ].vals()
     ) {
       let response = await IcpTldOperator.lookup(domain, recordType);
-      let errMsg = "shouldNotLookupNonregisteredIcpDomain() failed for domain: " # domain # ", recordType: " # recordType # ", size of ";
-      assert isEqualInt(response.answers.size(), 0, errMsg # "answers");
-      assert isEqualInt(response.additionals.size(), 0, errMsg # "additionals");
-      assert isEqualInt(response.authorities.size(), 0, errMsg # "authorities");
+      let errMsg = "shouldNotLookupNonregisteredIcpDomain() failed for domain: " # domain # ", recordType: " # recordType # ", size of response.";
+      assert Test.isEqualInt(response.answers.size(), 0, errMsg # "answers");
+      assert Test.isEqualInt(response.additionals.size(), 0, errMsg # "additionals");
+      assert Test.isEqualInt(response.authorities.size(), 0, errMsg # "authorities");
     };
   };
 
@@ -84,10 +62,10 @@ actor {
       assert isTrue(registerResponse.success, asText(registerResponse.message));
 
       let lookupResponse = await IcpTldOperator.lookup(domain, recordType);
-      let errMsg = "shouldRegisterAndLookupIcpDomain() failed for domain: " # domain # ", recordType: " # recordType # ", size of ";
-      assert isEqualInt(lookupResponse.answers.size(), 1, errMsg # "answers");
-      assert isEqualInt(lookupResponse.additionals.size(), 0, errMsg # "additionals");
-      assert isEqualInt(lookupResponse.authorities.size(), 0, errMsg # "authorities");
+      let errMsg = "shouldRegisterAndLookupIcpDomain() failed for domain: " # domain # ", recordType: " # recordType # ", size of response.";
+      assert Test.isEqualInt(lookupResponse.answers.size(), 1, errMsg # "answers");
+      assert Test.isEqualInt(lookupResponse.additionals.size(), 0, errMsg # "additionals");
+      assert Test.isEqualInt(lookupResponse.authorities.size(), 0, errMsg # "authorities");
 
       let responseDomainRecord = lookupResponse.answers[0];
       assert (responseDomainRecord == domainRecord);
@@ -116,7 +94,7 @@ actor {
       };
       let response = await IcpTldOperator.register(domain, registrationRecords);
       let errMsg = "shouldNotRegisterNonIcpDomain() failed for domain: " # domain;
-      assert isTrue(not response.success, errMsg);
+      assert Test.isTrue(not response.success, errMsg);
     };
   };
 
@@ -139,8 +117,8 @@ actor {
       };
       let response = await IcpTldOperator.register(domain, registrationRecords);
       let errMsg = "shouldNotRegisterIfInconsistentDomainRecord() failed for domain: " # domain;
-      assert isTrue(not response.success, errMsg);
-      assert textContains(asText(response.message), "Inconsistent domain record", errMsg);
+      assert Test.isTrue(not response.success, errMsg);
+      assert Test.textContains(asText(response.message), "Inconsistent domain record", errMsg);
     };
   };
 
@@ -163,8 +141,8 @@ actor {
       };
       let response = await IcpTldOperator.register(domain, registrationRecords);
       let errMsg = "shouldNotRegisterDomainIfNotController() failed for domain: " # domain;
-      assert isTrue(not response.success, errMsg);
-      assert textContains(asText(response.message), "only a canister controller can register", errMsg);
+      assert Test.isTrue(not response.success, errMsg);
+      assert Test.textContains(asText(response.message), "only a canister controller can register", errMsg);
     };
   };
 

--- a/minimal_cns/src/backend/tld_operator.test.mo
+++ b/minimal_cns/src/backend/tld_operator.test.mo
@@ -1,6 +1,5 @@
 import NameRegistry "canister:name_registry";
 import IcpTldOperator "canister:tld_operator";
-import Debug "mo:base/Debug";
 import Option "mo:base/Option";
 import Text "mo:base/Text";
 import Test "../test_utils"
@@ -59,7 +58,7 @@ actor {
         records = ?[domainRecord];
       };
       let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
-      assert isTrue(registerResponse.success, asText(registerResponse.message));
+      assert Test.isTrue(registerResponse.success, asText(registerResponse.message));
 
       let lookupResponse = await IcpTldOperator.lookup(domain, recordType);
       let errMsg = "shouldRegisterAndLookupIcpDomain() failed for domain: " # domain # ", recordType: " # recordType # ", size of response.";

--- a/minimal_cns/src/test_utils.mo
+++ b/minimal_cns/src/test_utils.mo
@@ -2,7 +2,7 @@ import Debug "mo:base/Debug";
 import Text "mo:base/Text";
 
 module {
-  public unc isEqualInt(actual : Int, expected : Int, errMsg : Text) : Bool {
+  public func isEqualInt(actual : Int, expected : Int, errMsg : Text) : Bool {
     let isEq = actual == expected;
     if (not isEq) {
       Debug.print("Expected Int: " # debug_show (expected) # ", got: " # debug_show (actual) # "; error: " # errMsg);
@@ -10,7 +10,7 @@ module {
     return isEq;
   };
 
-  public unc isEqualText(actual : Text, expected : Test, errMsg : Text) : Bool {
+  public func isEqualText(actual : Text, expected : Text, errMsg : Text) : Bool {
     let isEq = actual == expected;
     if (not isEq) {
       Debug.print("Expected Text: '" # debug_show (expected) # "', got: '" # debug_show (actual) # "'; error: " # errMsg);

--- a/minimal_cns/src/test_utils.mo
+++ b/minimal_cns/src/test_utils.mo
@@ -1,0 +1,35 @@
+import Debug "mo:base/Debug";
+import Text "mo:base/Text";
+
+module {
+  public unc isEqualInt(actual : Int, expected : Int, errMsg : Text) : Bool {
+    let isEq = actual == expected;
+    if (not isEq) {
+      Debug.print("Expected Int: " # debug_show (expected) # ", got: " # debug_show (actual) # "; error: " # errMsg);
+    };
+    return isEq;
+  };
+
+  public unc isEqualText(actual : Text, expected : Test, errMsg : Text) : Bool {
+    let isEq = actual == expected;
+    if (not isEq) {
+      Debug.print("Expected Text: '" # debug_show (expected) # "', got: '" # debug_show (actual) # "'; error: " # errMsg);
+    };
+    return isEq;
+  };
+
+  public func textContains(text : Text, subText : Text, errMsg : Text) : Bool {
+    let contains = Text.contains(text, #text subText);
+    if (not contains) {
+      Debug.print("Expected text '" # text # "' to contain '" # subText # "', error: " # errMsg);
+    };
+    return contains;
+  };
+
+  public func isTrue(actual : Bool, errMsg : Text) : Bool {
+    if (not actual) {
+      Debug.print("Expected Bool to be true, error: " # errMsg);
+    };
+    return actual;
+  };
+};


### PR DESCRIPTION
Factor out test functions `test_utils`-module, so that they can be used in other tests. 
Use the new module in existing tests, and simplify the test setup for `tld_operator`-tests.