### PR TITLE
feat: add to metrics data about most-looked-up domains

### DIFF
--- a/minimal_cns/src/backend/cns_root.mo
+++ b/minimal_cns/src/backend/cns_root.mo
@@ -150,7 +150,7 @@ shared actor class () {
     if (not Principal.isController(caller)) {
       return #err("Currently only a controller can get metrics");
     };
-    return #ok(metrics.getMetrics(period));
+    return #ok(metrics.getMetrics(period, [("ncRecordsCount", answersWrapper.size(lookupAnswersMap))]));
   };
 
   public shared ({ caller }) func purge_metrics() : async Result.Result<Nat, Text> {

--- a/minimal_cns/src/backend/tld_operator.mo
+++ b/minimal_cns/src/backend/tld_operator.mo
@@ -106,7 +106,7 @@ actor TldOperator {
     if (not Principal.isController(caller)) {
       return #err("Currently only a controller can get metrics");
     };
-    return #ok(metrics.getMetrics(period));
+    return #ok(metrics.getMetrics(period, [("cidRecordsCount", answersWrapper.size(lookupAnswersMap))]));
   };
 
   public shared ({ caller }) func purge_metrics() : async Result.Result<Nat, Text> {

--- a/minimal_cns/src/test_utils.mo
+++ b/minimal_cns/src/test_utils.mo
@@ -41,4 +41,14 @@ module {
     };
     return actual;
   };
+
+  public func compareLookupCounts(a : (Text, Nat), b : (Text, Nat)) : {
+    #less;
+    #equal;
+    #greater;
+  } {
+    if (a.1 > b.1) { #less } else if (a.1 < b.1) { #greater } else {
+      Text.compare(a.0, b.0);
+    };
+  };
 };


### PR DESCRIPTION
Add to metrics data about "most frequently looked up" domains, and also an option to add extra data (e.g. dependent on the actual canister state).