### PR TITLE
feat: add controllers to cns records

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -84,10 +84,12 @@ jobs:
           dfx deploy --no-wallet tld_operator_test
           echo "Calling runTestsIfNotController on canister tld_operator_test ..."
           dfx canister call tld_operator_test runTestsIfNotController "()"
+          echo "Calling runTestsIfOtherCallerNotController on canister tld_operator_test_other_caller ..."
+          dfx canister call tld_operator_test_other_caller runTestsIfOtherCallerNotController "()"
           echo "Adding tld_operator_test-canister as a controller of tld_operator-canister..."
           dfx canister update-settings tld_operator --add-controller `dfx canister id tld_operator_test`
-          echo "Calling runTests on canister tld_operator_test..."
-          dfx canister call tld_operator_test runTests "()"
+          echo "Calling runTestsIfController on canister tld_operator_test..."
+          dfx canister call tld_operator_test runTestsIfController "()"
 
       - name: 'Stop DFX'
         run: dfx stop

--- a/dfx.json
+++ b/dfx.json
@@ -27,6 +27,15 @@
     "tld_operator_test": {
       "main": "minimal_cns/src/backend/tld_operator.test.mo",
       "type": "motoko",
+      "dependencies": [
+        "name_registry",
+        "tld_operator",
+        "tld_operator_test_other_caller"
+      ]
+    },
+    "tld_operator_test_other_caller": {
+      "main": "minimal_cns/src/backend/tld_operator.test.mo",
+      "type": "motoko",
       "dependencies": ["name_registry", "tld_operator"]
     },
     "name_registry": {

--- a/minimal_cns/src/backend/cns_root.test.mo
+++ b/minimal_cns/src/backend/cns_root.test.mo
@@ -1,4 +1,3 @@
-import Array "mo:base/Array";
 import CnsRoot "canister:cns_root";
 import Debug "mo:base/Debug";
 import Metrics "metrics";

--- a/minimal_cns/src/backend/cns_types.mo
+++ b/minimal_cns/src/backend/cns_types.mo
@@ -11,6 +11,15 @@ module {
     message : ?Text;
   };
 
+  public func normalizedDomainRecord(record : DomainRecord) : DomainRecord {
+    return {
+      name = Text.toLowercase(record.name);
+      record_type = Text.toUppercase(record.record_type);
+      ttl = record.ttl;
+      data = record.data;
+    };
+  };
+
   public type RegisterResult = OperationResult;
 
   public type RegistrationControllerRole = {

--- a/minimal_cns/src/backend/tld_operator.test.mo
+++ b/minimal_cns/src/backend/tld_operator.test.mo
@@ -299,8 +299,8 @@ actor {
   // registering some test domains, but it should use a different caller then the registrant.
   func shouldNotOverwriteTestDomainIfNotRegistrantOrController() : async () {
     Debug.print("    test shouldNotOverwriteTestDomainIfNotRegistrantOrController...");
+    // The test data is a subset from shouldRegisterAndLookupIcpTestDomainIfNotController()
     for (
-      // The test data is a subset from shouldRegisterAndLookupIcpTestDomainIfNotController()
       (domain, recordType, canisterId) in [
         ("example.test.icp.", "Cid", "em77e-bvlzu-aq"),
         ("another.test.ICP.", "cid", "un4fu-tqaaa-aaaab-qadjq-cai"),

--- a/minimal_cns/src/backend/tld_operator.test.mo
+++ b/minimal_cns/src/backend/tld_operator.test.mo
@@ -305,7 +305,7 @@ actor {
         ("example.test.icp.", "Cid", "em77e-bvlzu-aq"),
         ("another.test.ICP.", "cid", "un4fu-tqaaa-aaaab-qadjq-cai"),
         ("one.more.test.Icp.", "CId", "2vxsx-fae"),
-      ].vals(),
+      ].vals()
     ) {
       let expectedDomainRecord : DomainRecord = {
         name = domain;

--- a/minimal_cns/src/backend/tld_operator.test.mo
+++ b/minimal_cns/src/backend/tld_operator.test.mo
@@ -3,6 +3,7 @@ import Debug "mo:base/Debug";
 import IcpTldOperator "canister:tld_operator";
 import Metrics "metrics";
 import Option "mo:base/Option";
+import Principal "mo:base/Principal";
 import Result "mo:base/Result";
 import Text "mo:base/Text";
 import Test "../test_utils";
@@ -11,19 +12,39 @@ import Types "cns_types";
 actor {
   type DomainRecord = Types.DomainRecord;
 
-  public func runTests() : async () {
+  public func runTestsIfController() : async () {
+    Debug.print("--- starting runTestsIfController...");
     await shouldNotLookupNonregisteredIcpDomain();
-    await shouldRegisterAndLookupIcpDomain();
+    await shouldRegisterAndLookupIcpDomainIfController();
     await shouldGetMetrics();
     await shouldNotRegisterNonIcpDomain();
     await shouldNotRegisterIfInconsistentDomainRecord();
-    await shouldNotRegisterTldIfMissingDomainRecord();
-    await shouldNotRegisterTldIfMultipleDomainRecords();
+    await shouldNotRegisterIfMissingDomainRecord();
+    await shouldNotRegisterIfMultipleDomainRecords();
+    await shouldNotRegisterTestDomainIfBadCanisterId();
+    await shouldNotRegisterTestDomainIfNotCid();
+    await shouldNotRegisterTestDomainIfExplicitController();
+    await shouldNotRegisterTestDomainIfInconsistentDomainRecord();
+    await shouldNotRegisterTestDomainIfNotDotIcp();
+    await shouldOverwriteTestDomainIfController();
   };
 
   public func runTestsIfNotController() : async () {
-    await shouldNotRegisterDomainIfNotController();
+    Debug.print("--- starting runTestsIfNotController...");
+    await shouldNotRegisterIcpDomainIfNotController();
+    await shouldRegisterAndLookupIcpTestDomainIfNotController();
     await shouldNotReturnOrPurgeMetricsIfNotController();
+    await shouldNotRegisterTestDomainIfBadCanisterId();
+    await shouldNotRegisterTestDomainIfNotCid();
+    await shouldNotRegisterTestDomainIfExplicitController();
+    await shouldNotRegisterTestDomainIfInconsistentDomainRecord();
+    await shouldNotRegisterTestDomainIfNotDotIcp();
+  };
+
+  public func runTestsIfOtherCallerNotController() : async () {
+    Debug.print("--- starting runTestsIfNotController...");
+    await shouldNotOverwriteTestDomainIfNotRegistrantOrController();
+    await shouldRegisterTestDomainOtherCallerRegistrant();
   };
 
   func asText(maybeText : ?Text) : Text {
@@ -31,6 +52,7 @@ actor {
   };
 
   func shouldNotLookupNonregisteredIcpDomain() : async () {
+    Debug.print("    test shouldNotLookupNonregisteredIcpDomain...");
     for (
       (domain, recordType) in [
         ("first.example.icp.", "CID"),
@@ -46,7 +68,8 @@ actor {
     };
   };
 
-  func shouldRegisterAndLookupIcpDomain() : async () {
+  func shouldRegisterAndLookupIcpDomainIfController() : async () {
+    Debug.print("    test shouldRegisterAndLookupIcpDomainIfController...");
     for (
       (domain, recordType) in [
         ("my_domain.icp.", "CID"),
@@ -59,7 +82,7 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaa-aaaa";
+        data = "aaaaa-aa";
       };
       let registrationRecords = {
         controller = [];
@@ -69,17 +92,18 @@ actor {
       assert Test.isTrue(registerResponse.success, asText(registerResponse.message));
 
       let lookupResponse = await IcpTldOperator.lookup(domain, recordType);
-      let errMsg = "shouldRegisterAndLookupIcpDomain() failed for domain: " # domain # ", recordType: " # recordType # ", size of response.";
+      let errMsg = "shouldRegisterAndLookupIcpDomainIfController() failed for domain: " # domain # ", recordType: " # recordType # ", size of response.";
       assert Test.isEqualInt(lookupResponse.answers.size(), 1, errMsg # "answers");
       assert Test.isEqualInt(lookupResponse.additionals.size(), 0, errMsg # "additionals");
       assert Test.isEqualInt(lookupResponse.authorities.size(), 0, errMsg # "authorities");
 
       let responseDomainRecord = lookupResponse.answers[0];
-      assert (responseDomainRecord == domainRecord);
+      assert Test.isEqualDomainRecord(responseDomainRecord, domainRecord);
     };
   };
 
   func shouldGetMetrics() : async () {
+    Debug.print("    test shouldGetMetrics...");
     // Purge metrics to be independent of other tests
     let purgeResult = await IcpTldOperator.purge_metrics();
     Result.assertOk(purgeResult);
@@ -104,7 +128,7 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaa-aaaa";
+        data = "aaaaa-aa";
       };
       let registrationRecords = {
         controller = [];
@@ -133,7 +157,7 @@ actor {
         success = goodDomainCount + extraGoodLookupsCount;
       };
       registerCount = { fail = badDomainCount; success = goodDomainCount };
-      extras = [("cidRecordsCount", 4)];
+      extras = [("cidRecordsCount", 9)]; // 4 registered in this test, and 5 test domains registered previously.
       topLookups = Array.sort<(Text, Nat)>(expectedLookupCounts, Test.compareLookupCounts);
       sinceTimestamp = metricsData.sinceTimestamp; // cannot predict this field
     };
@@ -151,7 +175,7 @@ actor {
       logLength = 0;
       lookupCount = { fail = 0; success = 0 };
       registerCount = { fail = 0; success = 0 };
-      extras = [("cidRecordsCount", 4)];
+      extras = [("cidRecordsCount", 9)];
       topLookups = [];
       sinceTimestamp = newMetricsData.sinceTimestamp; // cannot predict this field
     };
@@ -159,6 +183,7 @@ actor {
   };
 
   func shouldNotRegisterNonIcpDomain() : async () {
+    Debug.print("    test shouldNotRegisterNonIcpDomain...");
     for (
       (domain) in [
         (".fun."),
@@ -172,7 +197,7 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaa-aaaa";
+        data = "aaaaa-aa";
       };
       let registrationRecords = {
         controller = [];
@@ -186,6 +211,7 @@ actor {
   };
 
   func shouldNotRegisterIfInconsistentDomainRecord() : async () {
+    Debug.print("    test shouldNotRegisterIfInconsistentDomainRecord...");
     for (
       (domain, record_name) in [
         ("some.name.icp.", "other.domain.icp."),
@@ -196,7 +222,7 @@ actor {
         name = record_name;
         record_type = "CID";
         ttl = 3600;
-        data = "aaa-aaaa";
+        data = "aaaaa-aa";
       };
       let registrationRecords = {
         controller = [];
@@ -209,7 +235,8 @@ actor {
     };
   };
 
-  func shouldNotRegisterDomainIfNotController() : async () {
+  func shouldNotRegisterIcpDomainIfNotController() : async () {
+    Debug.print("    test shouldNotRegisterIcpDomainIfNotController...");
     for (
       (domain) in [
         ("my_domain.icp."),
@@ -220,20 +247,261 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaa-aaaa";
+        data = "aaaaa-aa";
       };
       let registrationRecords = {
         controller = [];
         records = ?[domainRecord];
       };
       let response = await IcpTldOperator.register(domain, registrationRecords);
-      let errMsg = "shouldNotRegisterDomainIfNotController() failed for domain: " # domain;
+      let errMsg = "shouldNotRegisterIcpDomainIfNotController() failed for domain: " # domain;
       assert Test.isTrue(not response.success, errMsg);
       assert Test.textContains(asText(response.message), "only a canister controller can register", errMsg);
     };
   };
 
+  func shouldRegisterAndLookupIcpTestDomainIfNotController() : async () {
+    Debug.print("    test shouldRegisterAndLookupIcpTestDomainIfNotController...");
+    for (
+      (domain, recordType, canisterId) in [
+        ("my_domain.test.icp.", "CID", "aaaaa-aa"),
+        ("example.test.icp.", "Cid", "em77e-bvlzu-aq"),
+        ("another.test.ICP.", "cid", "un4fu-tqaaa-aaaab-qadjq-cai"),
+        ("one.more.test.Icp.", "CId", "2vxsx-fae"),
+        ("my_domain.test.icp.", "CID", "2vxsx-fae"), // overwrite previous mapping
+      ].vals()
+    ) {
+      let domainRecord : DomainRecord = {
+        name = domain;
+        record_type = recordType;
+        ttl = 3600;
+        data = canisterId;
+      };
+      let registrationRecords = {
+        controller = [];
+        records = ?[domainRecord];
+      };
+      let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+      assert Test.isTrue(registerResponse.success, asText(registerResponse.message));
+
+      let lookupResponse = await IcpTldOperator.lookup(domain, recordType);
+      let errMsg = "shouldRegisterAndLookupIcpTestDomainIfNotController() failed for domain: " # domain # ", recordType: " # recordType # ", size of response.";
+      assert Test.isEqualInt(lookupResponse.answers.size(), 1, errMsg # "answers");
+      assert Test.isEqualInt(lookupResponse.additionals.size(), 0, errMsg # "additionals");
+      assert Test.isEqualInt(lookupResponse.authorities.size(), 0, errMsg # "authorities");
+
+      let responseDomainRecord = lookupResponse.answers[0];
+      assert Test.isEqualDomainRecord(responseDomainRecord, domainRecord);
+    };
+  };
+
+  // This test should be run after shouldRegisterAndLookupIcpTestDomainIfNotController() finished
+  // registering some test domains, but it should use a different caller then the registrant.
+  func shouldNotOverwriteTestDomainIfNotRegistrantOrController() : async () {
+    Debug.print("    test shouldNotOverwriteTestDomainIfNotRegistrantOrController...");
+    for (
+      // The test data is a subset from shouldRegisterAndLookupIcpTestDomainIfNotController()
+      (domain, recordType, canisterId) in [
+        ("example.test.icp.", "Cid", "em77e-bvlzu-aq"),
+        ("another.test.ICP.", "cid", "un4fu-tqaaa-aaaab-qadjq-cai"),
+        ("one.more.test.Icp.", "CId", "2vxsx-fae"),
+      ].vals(),
+    ) {
+      let expectedDomainRecord : DomainRecord = {
+        name = domain;
+        record_type = recordType;
+        ttl = 3600;
+        data = canisterId;
+      };
+      let newDomainRecord : DomainRecord = {
+        name = domain;
+        record_type = "CID";
+        ttl = 3600;
+        data = "aaaaa-aa"; // try to override an existing mapping
+      };
+      let registrationRecords = {
+        controller = [];
+        records = ?[newDomainRecord];
+      };
+      let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+      assert Test.isFalse(registerResponse.success, "Registration of " # domain # " succeeded unexpectedly");
+      assert Test.textContains(asText(registerResponse.message), "does not match the registrant", "Registration of " # domain # " failed for a wrong reason");
+
+      let lookupResponse = await IcpTldOperator.lookup(domain, recordType);
+      let errMsg = "shouldNotOverwriteTestDomainIfNotRegistrantOrController() failed for domain: " # domain # ", recordType: " # recordType # ", size of response.";
+      assert Test.isEqualInt(lookupResponse.answers.size(), 1, errMsg # "answers");
+      assert Test.isEqualInt(lookupResponse.additionals.size(), 0, errMsg # "additionals");
+      assert Test.isEqualInt(lookupResponse.authorities.size(), 0, errMsg # "authorities");
+
+      let responseDomainRecord = lookupResponse.answers[0];
+      assert Test.isEqualDomainRecord(responseDomainRecord, expectedDomainRecord);
+    };
+  };
+
+  func shouldRegisterTestDomainOtherCallerRegistrant() : async () {
+    Debug.print("    test shouldRegisterTestDomainOtherCallerRegistrant...");
+    let domain = "to-be-overriden.test.icp.";
+    let canisterId = "2vxsx-fae";
+    let record : DomainRecord = {
+      name = domain;
+      record_type = "CID";
+      ttl = 3600;
+      data = canisterId;
+    };
+    let registrationRecords = {
+      controller = [];
+      records = ?[record];
+    };
+    let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+    assert Test.isTrue(registerResponse.success, "Registration of " # domain # " failed unexpectedly with error" # debug_show (registerResponse.message));
+  };
+
+  func shouldOverwriteTestDomainIfController() : async () {
+    Debug.print("    test shouldOverwriteTestDomainIfController...");
+    let domain = "to-be-overriden.test.icp.";
+    let canisterId = "2vxsx-fae";
+    let expectedDomainRecord : DomainRecord = {
+      name = domain;
+      record_type = "CID";
+      ttl = 3600;
+      data = canisterId;
+    };
+
+    // Lookup previous registration.
+    let lookupResponse = await IcpTldOperator.lookup(domain, "CID");
+    let errMsg = "shouldRegisterTestDomainOtherCaller() failed for domain: " # domain # ", size of response.";
+    assert Test.isEqualInt(lookupResponse.answers.size(), 1, errMsg # "answers");
+    assert Test.isEqualInt(lookupResponse.additionals.size(), 0, errMsg # "additionals");
+    assert Test.isEqualInt(lookupResponse.authorities.size(), 0, errMsg # "authorities");
+
+    let responseDomainRecord = lookupResponse.answers[0];
+    assert Test.isEqualDomainRecord(responseDomainRecord, expectedDomainRecord);
+
+    // Overwrite the registration
+    let newDomainRecord : DomainRecord = {
+      name = domain;
+      record_type = "CID";
+      ttl = 600; // different ttl
+      data = "aaaaa-aa"; // different canister id
+    };
+    let registrationRecords = {
+      controller = [];
+      records = ?[newDomainRecord];
+    };
+
+    let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+    assert Test.isTrue(registerResponse.success, "Registration of " # domain # " failed unexpectedly with error" # debug_show (registerResponse.message));
+
+    // Lookup the new record.
+    let newLookupResponse = await IcpTldOperator.lookup(domain, "CID");
+    assert Test.isEqualInt(newLookupResponse.answers.size(), 1, errMsg # "answers");
+    assert Test.isEqualInt(newLookupResponse.additionals.size(), 0, errMsg # "additionals");
+    assert Test.isEqualInt(newLookupResponse.authorities.size(), 0, errMsg # "authorities");
+
+    let newResponseDomainRecord = newLookupResponse.answers[0];
+    assert Test.isEqualDomainRecord(newResponseDomainRecord, newDomainRecord);
+  };
+
+  func shouldNotRegisterTestDomainIfBadCanisterId() : async () {
+    Debug.print("    test shouldNotRegisterTestDomainIfBadCanisterId...");
+    let domain = "example.test.icp.";
+    let record : DomainRecord = {
+      name = domain;
+      record_type = "CID";
+      ttl = 3600;
+      data = "bad-canister-id";
+    };
+    let registrationRecords = {
+      controller = [];
+      records = ?[record];
+    };
+    try {
+      let _ = await IcpTldOperator.register(domain, registrationRecords);
+    } catch (_) {
+      // expected
+      return;
+    };
+    Debug.trap("Registration with bad canister id did not trap");
+  };
+
+  func shouldNotRegisterTestDomainIfNotCid() : async () {
+    Debug.print("    test shouldNotRegisterTestDomainIfNotCid...");
+    let domain = "example.test.icp.";
+    let record : DomainRecord = {
+      name = domain;
+      record_type = "NS";
+      ttl = 3600;
+      data = "aaaaa-aa";
+    };
+    let registrationRecords = {
+      controller = [];
+      records = ?[record];
+    };
+    let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+    assert Test.isFalse(registerResponse.success, "Registration of " # domain # " succeeded unexpectedly");
+    assert Test.textContains(asText(registerResponse.message), "only CID-records can be registered", "Registration of " # domain # " failed for a wrong reason");
+  };
+
+  func shouldNotRegisterTestDomainIfExplicitController() : async () {
+    Debug.print("    test shouldNotRegisterTestDomainIfExplicitController...");
+    let domain = "example.test.icp.";
+    let record : DomainRecord = {
+      name = domain;
+      record_type = "CID";
+      ttl = 3600;
+      data = "aaaaa-aa";
+    };
+    let registrationRecords : Types.RegistrationRecords = {
+      controller = [{
+        principal = Principal.fromText("aaaaa-aa");
+        roles : [Types.RegistrationControllerRole] = [#registrant];
+      }];
+      records = ?[record];
+    };
+    let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+    assert Test.isFalse(registerResponse.success, "Registration of " # domain # " succeeded unexpectedly");
+    assert Test.textContains(asText(registerResponse.message), "no explicit controller setting is supported", "Registration of " # domain # " failed for a wrong reason");
+  };
+
+  func shouldNotRegisterTestDomainIfInconsistentDomainRecord() : async () {
+    Debug.print("    test shouldNotRegisterTestDomainIfInconsistentDomainRecord...");
+    let domain = "example.test.icp.";
+    let record : DomainRecord = {
+      name = "other.domain.test.icp.";
+      record_type = "CID";
+      ttl = 3600;
+      data = "aaaaa-aa";
+    };
+    let registrationRecords = {
+      controller = [];
+      records = ?[record];
+    };
+    let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+    assert Test.isFalse(registerResponse.success, "Registration of " # domain # " succeeded unexpectedly");
+    assert Test.textContains(asText(registerResponse.message), "Inconsistent domain record", "Registration of " # domain # " failed for a wrong reason");
+  };
+
+  func shouldNotRegisterTestDomainIfNotDotIcp() : async () {
+    Debug.print("    test shouldNotRegisterTestDomainIfNotDotIcp...");
+    let domain = "example.test.org.";
+    let record : DomainRecord = {
+      name = domain;
+      record_type = "CID";
+      ttl = 3600;
+      data = "aaaaa-aa";
+    };
+    let registrationRecords = {
+      controller = [];
+      records = ?[record];
+    };
+    let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
+    assert Test.isFalse(registerResponse.success, "Registration of " # domain # " succeeded unexpectedly");
+    assert Test.textContains(asText(registerResponse.message), "Unsupported TLD", "Registration of " # domain # " failed for a wrong reason");
+  };
+
   func shouldNotReturnOrPurgeMetricsIfNotController() : async () {
+    Debug.print("    test shouldNotReturnOrPurgeMetricsIfNotController...");
+
     let metricsResult = await IcpTldOperator.get_metrics("hour");
     var errMsg = "shouldNotReturnOrPurgeMetricsIfNotController() got unexpected result from get_metrics()-call";
     assert Test.isTrue(Result.isErr(metricsResult), errMsg);
@@ -245,27 +513,29 @@ actor {
     assert Test.textContains(debug_show (purgeResult), "only a controller can purge metrics", errMsg);
   };
 
-  func shouldNotRegisterTldIfMissingDomainRecord() : async () {
+  func shouldNotRegisterIfMissingDomainRecord() : async () {
     let response = await IcpTldOperator.register(".icp.", { controller = []; records = null });
-    let errMsg = "shouldNotRegisterTldIfMissingDomainRecord() failed";
+    let errMsg = "shouldNotRegisterIfMissingDomainRecord() failed";
     assert Test.isTrue(not response.success, errMsg);
     assert Test.textContains(asText(response.message), "exactly one domain record", errMsg);
   };
 
-  func shouldNotRegisterTldIfMultipleDomainRecords() : async () {
+  func shouldNotRegisterIfMultipleDomainRecords() : async () {
+    Debug.print("    test shouldNotRegisterIfMultipleDomainRecords...");
+
     let domainRecord : Types.DomainRecord = {
       name = "example.icp.";
       record_type = "CID";
       ttl = 3600;
-      data = "aaa-aaaa";
+      data = "aaaaa-aa";
     };
     let registrationRecords = {
       controller = [];
       records = ?[domainRecord, domainRecord];
     };
     let response = await IcpTldOperator.register(".icp.", registrationRecords);
-    let errMsg = "shouldNotRegisterTldIfMultipleDomainRecords() failed for two DomainRecords";
-    assert Test.isTrue(not response.success, errMsg);
+    let errMsg = "shouldNotRegisterIfMultipleDomainRecords() failed for two DomainRecords";
+    assert Test.isFalse(response.success, errMsg);
     assert Test.textContains(asText(response.message), "exactly one domain record", errMsg);
   };
 

--- a/minimal_cns/src/test_utils.mo
+++ b/minimal_cns/src/test_utils.mo
@@ -1,6 +1,7 @@
 import Debug "mo:base/Debug";
 import Text "mo:base/Text";
 import Metrics "backend/metrics";
+import Types "backend/cns_types";
 
 module {
   public func isEqualInt(actual : Int, expected : Int, errMsg : Text) : Bool {
@@ -27,6 +28,14 @@ module {
     return isEq;
   };
 
+  public func isEqualDomainRecord(actual : Types.DomainRecord, expected : Types.DomainRecord) : Bool {
+    var isEq = Types.normalizedDomainRecord(actual) == Types.normalizedDomainRecord(expected);
+    if (not isEq) {
+      Debug.print("Expected DomainRecord: '" # debug_show (expected) # "', got: '" # debug_show (actual));
+    };
+    return isEq;
+  };
+
   public func textContains(text : Text, subText : Text, errMsg : Text) : Bool {
     let contains = Text.contains(text, #text subText);
     if (not contains) {
@@ -40,6 +49,13 @@ module {
       Debug.print("Expected Bool to be true, error: " # errMsg);
     };
     return actual;
+  };
+
+  public func isFalse(actual : Bool, errMsg : Text) : Bool {
+    if (actual) {
+      Debug.print("Expected Bool to be false, error: " # errMsg);
+    };
+    return not actual;
   };
 
   public func compareLookupCounts(a : (Text, Nat), b : (Text, Nat)) : {


### PR DESCRIPTION
Record the caller as a controller/registrant of the registered domain.
Allow registration of arbitrary subdomains of `.test.icp` to callers that are not controllers of the TLD-operator canister.

TT-522