### PR TITLE
ci: enable code commit and style checks on pushes to dev-branches

### DIFF
--- a/.github/workflows/check-commits.yaml
+++ b/.github/workflows/check-commits.yaml
@@ -12,6 +12,15 @@ on:
     types: [checks_requested]
     branches:
       - main
+  push:
+    branches:
+      - main
+      # For external contributions, the suggested flow is as follows:
+      #   1. Contributor creates a fork and enables GH Actions on it
+      #   2. Contributor develops in a fork, and pushes the changes to a branch named with prefix `dev-gh-`.
+      #      The push triggers the tests on the contributor's fork on a Github Runner
+      #   3. Once the code in a branch is ready and passes the tests, the contributor creates a PR on the main repo.
+      - 'dev-gh-*'
 
 jobs:
   check_pr_title:

--- a/.github/workflows/code-style.yaml
+++ b/.github/workflows/code-style.yaml
@@ -12,6 +12,15 @@ on:
     types: [checks_requested]
     branches:
       - main
+  push:
+    branches:
+      - main
+      # For external contributions, the suggested flow is as follows:
+      #   1. Contributor creates a fork and enables GH Actions on it
+      #   2. Contributor develops in a fork, and pushes the changes to a branch named with prefix `dev-gh-`.
+      #      The push triggers the tests on the contributor's fork on a Github Runner
+      #   3. Once the code in a branch is ready and passes the tests, the contributor creates a PR on the main repo.
+      - 'dev-gh-*'
 
 env:
   # When getting Rust dependencies, retry on network error:


### PR DESCRIPTION
As a follow up to #105, trigger also commit and code style checks on pushes to dev-branches. 