### PR TITLE
refactor: move top level apis to modules

### DIFF
--- a/minimal_cns/canisters/cns_root/lib.mo
+++ b/minimal_cns/canisters/cns_root/lib.mo
@@ -25,7 +25,7 @@ shared actor class () {
       metrics,
       domain,
       recordType,
-    ); 
+    );
   };
 
   public shared ({ caller }) func register(domain : Text, records : Types.RegistrationRecords) : async (Types.RegisterResult) {

--- a/minimal_cns/canisters/cns_root/lib.mo
+++ b/minimal_cns/canisters/cns_root/lib.mo
@@ -1,11 +1,11 @@
-import Iter "mo:base/Iter";
 import Map "mo:base/Map";
 import Text "mo:base/Text";
 import Metrics "../../common/metrics";
-import Option "mo:base/Option";
 import Principal "mo:base/Principal";
 import Result "mo:base/Result";
 import Types "../../common/cns_types";
+import Queries "queries";
+import Mutations "mutations";
 
 shared actor class () {
   let icpTld = ".icp.";
@@ -17,132 +17,29 @@ shared actor class () {
   stable var metricsStore : Metrics.LogStore = Metrics.newStore();
   let metrics = Metrics.CnsMetrics(metricsStore);
 
-  func getTld(domain : Text) : Text {
-    let parts = Text.split(domain, #char '.');
-    let array = Iter.toArray(parts);
-    if (array.size() >= 2) {
-      return "." # array[array.size() - 2] # ".";
-    } else {
-      return "..";
-    };
-  };
-
   public shared func lookup(domain : Text, recordType : Text) : async Types.DomainLookup {
-    var answers : [Types.DomainRecord] = [];
-    var authorities : [Types.DomainRecord] = [];
-
-    let domainLowercase : Text = Text.toLower(domain);
-    if (Text.endsWith(domainLowercase, #text icpTld)) {
-      let tld = getTld(domainLowercase);
-      switch (Text.toUpper(recordType)) {
-        case ("NC") {
-          let maybeRecord : ?Types.DomainRecord = Map.get(lookupAnswersMap, Text.compare, tld);
-          answers := switch maybeRecord {
-            case null { [] };
-            case (?record) { [record] };
-          };
-        };
-        case _ {
-          let maybeRecord : ?Types.DomainRecord = Map.get(lookupAuthoritiesMap, Text.compare, tld);
-          authorities := switch maybeRecord {
-            case null { [] };
-            case (?record) { [record] };
-          };
-        };
-      };
-    };
-    metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, (answers != [] or authorities != [])));
-    {
-      answers = answers;
-      additionals = [];
-      authorities = authorities;
-    };
-  };
-
-  // In addition th the `RegisterResult` this helper returns the relevant record type,
-  // so that the caller can properly log the operation.
-  func validateAndRegister(caller : Principal, domain : Text, records : Types.RegistrationRecords) : (Types.RegisterResult, Text) {
-    if (not Principal.isController(caller)) {
-      return (
-        {
-          success = false;
-          message = ?("Currently only a canister controller can register new TLD-operators, caller: " # Principal.toText(caller));
-        },
-        "",
-      );
-    };
-    let domainLowercase : Text = Text.toLower(domain);
-    let tld = getTld(domainLowercase);
-    if (tld != domainLowercase) {
-      return (
-        {
-          success = false;
-          message = ?("The given domain " # domain # " is not a TLD, its TLD is " # tld);
-        },
-        "",
-      );
-    };
-    if (tld != icpTld) {
-      return (
-        {
-          success = false;
-          message = ?("Currently only " # icpTld # "-TLD is supported; requested TLD: " # domain);
-        },
-        "",
-      );
-    };
-    let domainRecords = Option.get(records.records, []);
-    // TODO: remove the restriction of acceping exactly one domain record.
-    if (domainRecords.size() != 1) {
-      return (
-        {
-          success = false;
-          message = ?"Currently exactly one domain record must be specified.";
-        },
-        "",
-      );
-    };
-    let record : Types.DomainRecord = domainRecords[0];
-    let recordType = record.record_type;
-    if (tld != (Text.toLower(record.name))) {
-      return (
-        {
-          success = false;
-          message = ?("Inconsistent domain record, record.name: `" # record.name # "` doesn't match TLD: " # tld);
-        },
-        recordType,
-      );
-    };
-    // TODO: add more checks: validate domain name and all the fields of the domain record(s).
-
-    switch (Text.toUpper(record.record_type)) {
-      case ("NC") {
-        Map.add(lookupAnswersMap, Text.compare, tld, record);
-        Map.add(lookupAuthoritiesMap, Text.compare, tld, record);
-        return (
-          {
-            success = true;
-            message = null;
-          },
-          recordType,
-        );
-      };
-      case _ {
-        return (
-          {
-            success = false;
-            message = ?("Unsupported record_type: `" # record.record_type # "`, expected 'NC'");
-          },
-          recordType,
-        );
-      };
-    };
+    Queries.lookup(
+      icpTld,
+      lookupAnswersMap,
+      lookupAuthoritiesMap,
+      metrics,
+      domain,
+      recordType,
+    ); 
   };
 
   public shared ({ caller }) func register(domain : Text, records : Types.RegistrationRecords) : async (Types.RegisterResult) {
-    let (result, recordType) = validateAndRegister(caller, domain, records);
+    let (result, recordType) = Mutations.validateAndRegister(
+      caller,
+      icpTld,
+      domain,
+      lookupAnswersMap,
+      lookupAuthoritiesMap,
+      records,
+    );
     metrics.addEntry(metrics.makeRegisterEntry(Text.toLower(domain), recordType, result.success));
-    return result;
+
+    result;
   };
 
   public shared query ({ caller }) func get_metrics(period : Text) : async Result.Result<Metrics.MetricsData, Text> {

--- a/minimal_cns/canisters/cns_root/mutations.mo
+++ b/minimal_cns/canisters/cns_root/mutations.mo
@@ -1,0 +1,96 @@
+import Types "../../common/cns_types";
+import { getTldFromDomain }"parse";
+import Option "mo:base/Option";
+import Principal "mo:base/Principal";
+import Map "mo:base/Map";
+import Text "mo:base/Text";
+
+module {
+  // In addition th the `RegisterResult` this helper returns the relevant record type,
+  // so that the caller can properly log the operation.
+  public func validateAndRegister(
+    caller : Principal,
+    rootTld : Text,
+    domain : Text,
+    lookupAnswersMap : Map.Map<Text, Types.DomainRecord>,
+    lookupAuthoritiesMap : Map.Map<Text, Types.DomainRecord>,
+    records : Types.RegistrationRecords
+  ) : (Types.RegisterResult, Text) {
+    if (not Principal.isController(caller)) {
+      return (
+        {
+          success = false;
+          message = ?("Currently only a canister controller can register new TLD-operators, caller: " # Principal.toText(caller));
+        },
+        "",
+      );
+    };
+    let domainLowercase : Text = Text.toLower(domain);
+    let tld = getTldFromDomain(domainLowercase);
+    if (tld != domainLowercase) {
+      return (
+        {
+          success = false;
+          message = ?("The given domain " # domain # " is not a TLD, its TLD is " # tld);
+        },
+        "",
+      );
+    };
+    if (tld != rootTld) {
+      return (
+        {
+          success = false;
+          message = ?("Currently only " # rootTld # "-TLD is supported; requested TLD: " # domain);
+        },
+        "",
+      );
+    };
+    let domainRecords = Option.get(records.records, []);
+    // TODO: remove the restriction of acceping exactly one domain record.
+    if (domainRecords.size() != 1) {
+      return (
+        {
+          success = false;
+          message = ?"Currently exactly one domain record must be specified.";
+        },
+        "",
+      );
+    };
+    let record : Types.DomainRecord = domainRecords[0];
+    let recordType = record.record_type;
+    if (tld != (Text.toLower(record.name))) {
+      return (
+        {
+          success = false;
+          message = ?("Inconsistent domain record, record.name: `" # record.name # "` doesn't match TLD: " # tld);
+        },
+        recordType,
+      );
+    };
+    // TODO: add more checks: validate domain name and all the fields of the domain record(s).
+
+    switch (Text.toUpper(record.record_type)) {
+      case ("NC") {
+        Map.add(lookupAnswersMap, Text.compare, tld, record);
+        Map.add(lookupAuthoritiesMap, Text.compare, tld, record);
+
+        (
+          {
+            success = true;
+            message = null;
+          },
+          recordType,
+        );
+      };
+      case _ {
+        (
+          {
+            success = false;
+            message = ?("Unsupported record_type: `" # record.record_type # "`, expected 'NC'");
+          },
+          recordType,
+        );
+      };
+    };
+  };
+}

--- a/minimal_cns/canisters/cns_root/mutations.mo
+++ b/minimal_cns/canisters/cns_root/mutations.mo
@@ -1,5 +1,5 @@
 import Types "../../common/cns_types";
-import { getTldFromDomain }"parse";
+import { getTldFromDomain } "parse";
 import Option "mo:base/Option";
 import Principal "mo:base/Principal";
 import Map "mo:base/Map";
@@ -14,7 +14,7 @@ module {
     domain : Text,
     lookupAnswersMap : Map.Map<Text, Types.DomainRecord>,
     lookupAuthoritiesMap : Map.Map<Text, Types.DomainRecord>,
-    records : Types.RegistrationRecords
+    records : Types.RegistrationRecords,
   ) : (Types.RegisterResult, Text) {
     if (not Principal.isController(caller)) {
       return (
@@ -93,4 +93,4 @@ module {
       };
     };
   };
-}
+};

--- a/minimal_cns/canisters/cns_root/parse.mo
+++ b/minimal_cns/canisters/cns_root/parse.mo
@@ -10,4 +10,4 @@ module {
     let tldText = array[array.size() - 2];
     "." # tldText # ".";
   };
-}
+};

--- a/minimal_cns/canisters/cns_root/parse.mo
+++ b/minimal_cns/canisters/cns_root/parse.mo
@@ -1,0 +1,13 @@
+import Text "mo:base/Text";
+import Iter "mo:base/Iter";
+
+module {
+  public func getTldFromDomain(domain : Text) : Text {
+    let parts = Text.split(domain, #char '.');
+    let array = Iter.toArray(parts);
+    if (array.size() < 2) return "..";
+
+    let tldText = array[array.size() - 2];
+    "." # tldText # ".";
+  };
+}

--- a/minimal_cns/canisters/cns_root/queries.mo
+++ b/minimal_cns/canisters/cns_root/queries.mo
@@ -1,0 +1,47 @@
+import Types "../../common/cns_types";
+import MetricsTypes "../../common/metrics";
+import Map "mo:base/Map";
+import Text "mo:base/Text";
+import { getTldFromDomain } "parse";
+
+module {
+  public func lookup(
+    rootTld : Text,
+    lookupAnswersMap : Map.Map<Text, Types.DomainRecord>,
+    lookupAuthoritiesMap : Map.Map<Text, Types.DomainRecord>,
+    metrics : MetricsTypes.CnsMetrics,
+    domain : Text,
+    recordType : Text
+  ) : Types.DomainLookup{
+    var answers : [Types.DomainRecord] = [];
+    var authorities : [Types.DomainRecord] = [];
+
+    let domainLowercase : Text = Text.toLower(domain);
+    if (Text.endsWith(domainLowercase, #text rootTld)) {
+      let tld = getTldFromDomain(domainLowercase);
+      switch (Text.toUpper(recordType)) {
+        case ("NC") {
+          let maybeRecord : ?Types.DomainRecord = Map.get(lookupAnswersMap, Text.compare, tld);
+          answers := switch maybeRecord {
+            case null { [] };
+            case (?record) { [record] };
+          };
+        };
+        case _ {
+          let maybeRecord : ?Types.DomainRecord = Map.get(lookupAuthoritiesMap, Text.compare, tld);
+          authorities := switch maybeRecord {
+            case null { [] };
+            case (?record) { [record] };
+          };
+        };
+      };
+    };
+    metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, (answers != [] or authorities != [])));
+
+    {
+      answers = answers;
+      additionals = [];
+      authorities = authorities;
+    };
+  };
+}

--- a/minimal_cns/canisters/cns_root/queries.mo
+++ b/minimal_cns/canisters/cns_root/queries.mo
@@ -11,8 +11,8 @@ module {
     lookupAuthoritiesMap : Map.Map<Text, Types.DomainRecord>,
     metrics : MetricsTypes.CnsMetrics,
     domain : Text,
-    recordType : Text
-  ) : Types.DomainLookup{
+    recordType : Text,
+  ) : Types.DomainLookup {
     var answers : [Types.DomainRecord] = [];
     var authorities : [Types.DomainRecord] = [];
 
@@ -44,4 +44,4 @@ module {
       authorities = authorities;
     };
   };
-}
+};

--- a/minimal_cns/canisters/tld_operator/lib.mo
+++ b/minimal_cns/canisters/tld_operator/lib.mo
@@ -32,7 +32,7 @@ actor TldOperator {
       myTld,
       lookupAnswersMap,
       domainLowercase,
-      records
+      records,
     );
     metrics.addEntry(metrics.makeRegisterEntry(domainLowercase, recordType, result.success));
 

--- a/minimal_cns/canisters/tld_operator/mutations.mo
+++ b/minimal_cns/canisters/tld_operator/mutations.mo
@@ -14,7 +14,7 @@ module {
     myTld : Text,
     lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
     domainLowercase : Text,
-    records : Types.RegistrationRecords
+    records : Types.RegistrationRecords,
   ) : (Types.RegisterResult, Text) {
     let (domainRecord, maybeRegistrant) = switch (validateRegistrationRecords(myTld, lookupAnswersMap, domainLowercase, records)) {
       case (#ok(record, maybePrincipal)) { (record, maybePrincipal) };
@@ -80,7 +80,7 @@ module {
     myTld : Text,
     lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
     domainLowercase : Text,
-    records : Types.RegistrationRecords
+    records : Types.RegistrationRecords,
   ) : Result.Result<(Types.DomainRecord, ?Principal), Text> {
     let domainRecords = Option.get(records.records, []);
     // TODO: remove the restriction of acceping exactly one domain record.
@@ -118,5 +118,4 @@ module {
 
     #ok(Types.normalizedDomainRecord(record), maybeRegistrant);
   };
-}
-
+};

--- a/minimal_cns/canisters/tld_operator/mutations.mo
+++ b/minimal_cns/canisters/tld_operator/mutations.mo
@@ -1,0 +1,122 @@
+import Types "../../common/cns_types";
+import Map "mo:base/Map";
+import Result "mo:base/Result";
+import Text "mo:base/Text";
+import Principal "mo:base/Principal";
+import Option "mo:base/Option";
+import { trap } "mo:base/Runtime";
+
+module {
+  // In addition th the `RegisterResult` this helper returns the relevant record type,
+  // so that the caller can properly log the operation.
+  public func validateAndRegister(
+    caller : Principal,
+    myTld : Text,
+    lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
+    domainLowercase : Text,
+    records : Types.RegistrationRecords
+  ) : (Types.RegisterResult, Text) {
+    let (domainRecord, maybeRegistrant) = switch (validateRegistrationRecords(myTld, lookupAnswersMap, domainLowercase, records)) {
+      case (#ok(record, maybePrincipal)) { (record, maybePrincipal) };
+      case (#err(msg)) {
+        return (
+          {
+            success = false;
+            message = ?(msg);
+          },
+          "",
+        );
+      };
+    };
+
+    if (not Principal.isController(caller)) {
+      // Only subdomains of .test.icp are allowed for non-controllers
+      if (not Text.endsWith(domainLowercase, #text(".test" # myTld))) {
+        return (
+          {
+            success = false;
+            message = ?("Currently only a canister controller can register non-test " # myTld # "-domains, domain: " # domainLowercase # ", caller: " # Principal.toText(caller));
+          },
+          "",
+        );
+      };
+      // If the domain was registered previously, the caller must match the existing registrant.
+      switch (maybeRegistrant) {
+        case (null) {};
+        case (?registrant) {
+          if (registrant != caller) {
+            return (
+              {
+                success = false;
+                message = ?("Caller " # Principal.toText(caller) # " does not match the registrant " # Principal.toText(registrant));
+              },
+              "",
+            );
+          };
+        };
+      };
+    };
+    let registrationRecord = {
+      controller = [{
+        principal = caller;
+        roles = [#registrant];
+      }];
+      records = ?[domainRecord];
+    };
+    Map.add(lookupAnswersMap, Text.compare, domainLowercase, registrationRecord);
+
+    (
+      {
+        success = true;
+        message = null;
+      },
+      Text.toUpper(domainRecord.record_type),
+    );
+  };
+
+  // Validates the records, and if the domain already exisits, extracts the registrant.
+  // If validation fails, returns an error message.
+  func validateRegistrationRecords(
+    myTld : Text,
+    lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
+    domainLowercase : Text,
+    records : Types.RegistrationRecords
+  ) : Result.Result<(Types.DomainRecord, ?Principal), Text> {
+    let domainRecords = Option.get(records.records, []);
+    // TODO: remove the restriction of acceping exactly one domain record.
+    if (domainRecords.size() != 1) {
+      return #err("Currently exactly one domain record must be specified.");
+    };
+    // TODO: remove the restriction of not setting the controller(s) explicitly.
+    if (records.controller.size() != 0) {
+      return #err("Currently no explicit controller setting is supported.");
+    };
+    let record : Types.DomainRecord = domainRecords[0];
+    let recordType = Text.toUpper(record.record_type);
+    if (not Text.endsWith(domainLowercase, #text myTld)) {
+      return #err("Unsupported TLD in domain " # domainLowercase # ", expected TLD=" # myTld);
+    };
+    if (domainLowercase != Text.toLower(record.name)) {
+      return #err("Inconsistent domain record, record.name: `" # record.name # "` doesn't match domain: " # domainLowercase);
+    };
+    if (recordType != "CID") {
+      return #err("Currently only CID-records can be registered");
+    };
+    // TODO: don't trap on invalid Principals.
+    let _ = Principal.fromText(record.data);
+
+    let maybeRegistrant : ?Principal = switch (Map.get(lookupAnswersMap, Text.compare, domainLowercase)) {
+      case (null) { null };
+      case (?records) {
+        if (records.controller.size() == 0) {
+          trap("Internal error: missing registration controller for " # domainLowercase);
+        } else {
+          ?records.controller[0].principal;
+        };
+      };
+    };
+
+    #ok(Types.normalizedDomainRecord(record), maybeRegistrant);
+  };
+}
+

--- a/minimal_cns/canisters/tld_operator/queries.mo
+++ b/minimal_cns/canisters/tld_operator/queries.mo
@@ -10,7 +10,7 @@ module {
     lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
     metrics : MetricsTypes.CnsMetrics,
     domain : Text,
-    recordType : Text
+    recordType : Text,
   ) : Types.DomainLookup {
     var answers : [Types.DomainRecord] = [];
     let domainLowercase : Text = Text.toLower(domain);
@@ -37,5 +37,5 @@ module {
       additionals = [];
       authorities = [];
     };
-  }
-}
+  };
+};

--- a/minimal_cns/canisters/tld_operator/queries.mo
+++ b/minimal_cns/canisters/tld_operator/queries.mo
@@ -1,0 +1,41 @@
+import Map "mo:base/Map";
+import Types "../../common/cns_types";
+import MetricsTypes "../../common/metrics";
+import Option "mo:base/Option";
+import Text "mo:base/Text";
+
+module {
+  public func lookup(
+    myTld : Text,
+    lookupAnswersMap : Map.Map<Text, Types.RegistrationRecords>,
+    metrics : MetricsTypes.CnsMetrics,
+    domain : Text,
+    recordType : Text
+  ) : Types.DomainLookup {
+    var answers : [Types.DomainRecord] = [];
+    let domainLowercase : Text = Text.toLower(domain);
+
+    if (Text.endsWith(domainLowercase, #text myTld)) {
+      switch (Text.toUpper(recordType)) {
+        case ("CID") {
+          let maybeRecords : ?Types.RegistrationRecords = Map.get(lookupAnswersMap, Text.compare, domainLowercase);
+          answers := switch (maybeRecords) {
+            case (null) { [] };
+            case (?records) {
+              let domainRecords = Option.get(records.records, []);
+              if (domainRecords.size() == 0) { [] } else { [domainRecords[0]] };
+            };
+          };
+        };
+        case _ {};
+      };
+    };
+    metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, answers != []));
+
+    {
+      answers = answers;
+      additionals = [];
+      authorities = [];
+    };
+  }
+}


### PR DESCRIPTION
There isn't a good way to unit test Motoko canister code that is inside of the main actor file.

To more easily allow us to unit test the canisters in the future (not right now), this PR moves the logic out of the main actor into smaller modules.
