### PR TITLE
feat: Add SID and PTR record types

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -106,6 +106,7 @@ jobs:
           dfx canister update-settings tld_operator --add-controller `dfx canister id tld_operator_test`
           echo "Calling runTestsIfController on canister tld_operator_test..."
           dfx canister call tld_operator_test runTestsIfController "()"
+          dfx canister call tld_operator_test runPTRTestsIfController "()"
 
       - name: 'Stop DFX'
         run: dfx stop

--- a/lib/cns-js/tests/src/smoke-test.spec.ts
+++ b/lib/cns-js/tests/src/smoke-test.spec.ts
@@ -13,7 +13,7 @@ describe('Smoke test', () => {
   const cnsRoot = inject('CNS_ROOT');
   const dfxUrl = inject('DFX_URL');
 
-  const domainCanister = Principal.fromUint8Array(new Uint8Array([42]));
+  const domainCanister = Principal.fromText('r7inp-6aaaa-aaaaa-aaabq-cai');
 
   it('should lookup .test.icp NC and CID records', async () => {
     console.debug(addNcRecord(rawTld, tldOperator));

--- a/lib/ic-cns-canister-client/rs/tests/register_and_lookup.rs
+++ b/lib/ic-cns-canister-client/rs/tests/register_and_lookup.rs
@@ -124,7 +124,7 @@ fn should_register_and_lookup() {
     let env = CnsFixture::init();
     env.register_icp_nc();
     for (domain, cid_text) in [
-        ("example.icp.", "aaaaa-aa"),
+        ("example.icp.", "r7inp-6aaaa-aaaaa-aaabq-cai"),
         ("nns_governance.icp.", "rrkah-fqaaa-aaaaa-aaaaq-cai"),
         ("nns_registry.icp.", "rwlgt-iiaaa-aaaaa-aaaaa-cai"),
     ] {
@@ -139,7 +139,7 @@ fn should_register_and_lookup() {
 fn should_not_register_and_lookup_if_missing_nc() {
     let env = CnsFixture::init();
     for (domain, cid_text) in [
-        ("example.com.", "aaaaa-aa"),
+        ("example.com.", "r7inp-6aaaa-aaaaa-aaabq-cai"),
         ("nns_governance.icp.", "rrkah-fqaaa-aaaaa-aaaaq-cai"),
         ("nns_registry.icp.", "rwlgt-iiaaa-aaaaa-aaaaa-cai"),
     ] {
@@ -154,7 +154,7 @@ fn should_not_register_and_lookup_if_missing_nc() {
 fn should_not_register_and_lookup_if_not_icp_tld() {
     let env = CnsFixture::init();
     for (domain, cid_text) in [
-        ("example.com.", "aaaaa-aa"),
+        ("example.com.", "r7inp-6aaaa-aaaaa-aaabq-cai"),
         ("nns_governance.org.", "rrkah-fqaaa-aaaaa-aaaaq-cai"),
         ("nns_registry.edu.", "rwlgt-iiaaa-aaaaa-aaaaa-cai"),
     ] {

--- a/minimal_cns/canisters/tld_operator/queries.mo
+++ b/minimal_cns/canisters/tld_operator/queries.mo
@@ -21,6 +21,7 @@ module {
     recordType : Text,
   ) : ApiTypes.DomainLookup {
     let domainLowercase : Text = Text.toLower(domain);
+
     if (not Text.endsWith(domainLowercase, #text(myTld))) {
       metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, false));
       return EMPTY_DOMAIN_LOOKUP;
@@ -38,12 +39,12 @@ module {
     response;
   };
 
-  public func forwardLookup(
+  func forwardLookup(
     domainRecordsStore : DomainTypes.RegistrationRecordsStore,
-    domain : Text,
+    domainLowercase : Text,
   ) : ApiTypes.DomainLookup {
     // look up the domain record by the domain
-    let maybeRecords = Domain.RegistrationRecordsStore.getByDomain(domainRecordsStore, domain);
+    let maybeRecords = Domain.RegistrationRecordsStore.getByDomain(domainRecordsStore, domainLowercase);
     let answers = switch (maybeRecords) {
       case null { [] };
       case (?{ records }) {
@@ -61,12 +62,12 @@ module {
 
   // Reverse lookups have the format <principal>.reverse.<tld>
   // In this case, we expect the <principal> to be a valid principal.
-  public func reverseLookup(
+  func reverseLookup(
     domainRecordsStore : DomainTypes.RegistrationRecordsStore,
-    domain : Text,
+    domainLowercase : Text,
   ) : ApiTypes.DomainLookup {
     // split the domain into parts, based on "."
-    let parts = Iter.toArray(Text.split(domain, #char '.'));
+    let parts = Iter.toArray(Text.split(domainLowercase, #char '.'));
     // expect there to be exactly 3 parts: <principal>, reverse, <tld>
     // The 4th part is the 3rd period at the end (so parts[3] is the empty string)
     if (parts.size() != 4) {
@@ -84,7 +85,7 @@ module {
     };
 
     // look up the PTR domain record of the principal
-    let answers = switch (Domain.RegistrationRecordsStore.getPtrRecord(domainRecordsStore, domain, principal)) {
+    let answers = switch (Domain.RegistrationRecordsStore.getPtrRecord(domainRecordsStore, domainLowercase, principal)) {
       case null { [] };
       case (?record) { [record] };
     };

--- a/minimal_cns/canisters/tld_operator/queries.mo
+++ b/minimal_cns/canisters/tld_operator/queries.mo
@@ -22,7 +22,8 @@ module {
   ) : ApiTypes.DomainLookup {
     let domainLowercase : Text = Text.toLower(domain);
 
-    if (not Text.endsWith(domainLowercase, #text(myTld))) {
+    // If the lookup domain does not end with this TLD operator's TLD, return an empty lookup
+    if (not doesDomainEndInTLD(myTld, domainLowercase)) {
       metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, false));
       return EMPTY_DOMAIN_LOOKUP;
     };
@@ -95,5 +96,9 @@ module {
       additionals = [];
       authorities = [];
     };
+  };
+
+  func doesDomainEndInTLD(myTld : Text, domainLowercase : Text) : Bool {
+    Text.endsWith(domainLowercase, #text(myTld));
   };
 };

--- a/minimal_cns/canisters/tld_operator/queries.mo
+++ b/minimal_cns/canisters/tld_operator/queries.mo
@@ -68,8 +68,8 @@ module {
     // split the domain into parts, based on "."
     let parts = Iter.toArray(Text.split(domain, #char '.'));
     // expect there to be exactly 3 parts: <principal>, reverse, <tld>
-    // TODO: Is this assumption correct?
-    if (parts.size() != 3) {
+    // The 4th part is the 3rd period at the end (so parts[3] is the empty string)
+    if (parts.size() != 4) {
       return { answers = []; additionals = []; authorities = [] };
     };
 

--- a/minimal_cns/canisters/tld_operator/queries.mo
+++ b/minimal_cns/canisters/tld_operator/queries.mo
@@ -4,8 +4,15 @@ import Domain "../../common/data/domain";
 import MetricsTypes "../../common/metrics";
 import Option "mo:base/Option";
 import Text "mo:base/Text";
+import Iter "mo:base/Iter";
+import Principal "mo:base/Principal";
 
 module {
+  let EMPTY_DOMAIN_LOOKUP : ApiTypes.DomainLookup = {
+    answers = [];
+    additionals = [];
+    authorities = [];
+  };
   public func lookup(
     myTld : Text,
     lookupAnswersMap : DomainTypes.RegistrationRecordsStore,
@@ -13,28 +20,77 @@ module {
     domain : Text,
     recordType : Text,
   ) : ApiTypes.DomainLookup {
-    var answers : [DomainTypes.DomainRecord] = [];
     let domainLowercase : Text = Text.toLower(domain);
+    if (not Text.endsWith(domainLowercase, #text(myTld))) {
+      metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, false));
+      return EMPTY_DOMAIN_LOOKUP;
+    };
 
-    if (Text.endsWith(domainLowercase, #text myTld)) {
-      switch (Text.toUpper(recordType)) {
-        case ("CID") {
-          let maybeRecords : ?DomainTypes.RegistrationRecordsWithPrincipals = Domain.RegistrationRecordsStore.getByDomain(lookupAnswersMap, domainLowercase);
-          answers := switch (maybeRecords) {
-            case (null) { [] };
-            case (?{ records }) {
-              let domainRecords = Option.get(records.records, []);
-              if (domainRecords.size() == 0) { [] } else { [domainRecords[0]] };
-            };
-          };
-        };
-        case _ {};
+    let response = switch (Text.toUpper(recordType)) {
+      case ("CID" or "SID") { forwardLookup(lookupAnswersMap, domainLowercase) };
+      case ("PTR") { reverseLookup(lookupAnswersMap, domainLowercase) };
+      // Unsupported record types return an empty lookup
+      case _ { EMPTY_DOMAIN_LOOKUP };
+    };
+
+    metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, response.answers != []));
+
+    response;
+  };
+
+  public func forwardLookup(
+    domainRecordsStore : DomainTypes.RegistrationRecordsStore,
+    domain : Text,
+  ) : ApiTypes.DomainLookup {
+    // look up the domain record by the domain
+    let maybeRecords = Domain.RegistrationRecordsStore.getByDomain(domainRecordsStore, domain);
+    let answers = switch (maybeRecords) {
+      case null { [] };
+      case (?{ records }) {
+        let domainRecords = Option.get(records, []);
+        if (domainRecords.size() == 0) { [] } else { [domainRecords[0]] };
       };
     };
-    metrics.addEntry(metrics.makeLookupEntry(domainLowercase, recordType, answers != []));
 
     {
-      answers = answers;
+      answers;
+      additionals = [];
+      authorities = [];
+    };
+  };
+
+  // Reverse lookups have the format <principal>.reverse.<tld>
+  // In this case, we expect the <principal> to be a valid principal.
+  public func reverseLookup(
+    domainRecordsStore : DomainTypes.RegistrationRecordsStore,
+    domain : Text,
+  ) : ApiTypes.DomainLookup {
+    // split the domain into parts, based on "."
+    let parts = Iter.toArray(Text.split(domain, #char '.'));
+    // expect there to be exactly 3 parts: <principal>, reverse, <tld>
+    // TODO: Is this assumption correct?
+    if (parts.size() != 3) {
+      return { answers = []; additionals = []; authorities = [] };
+    };
+
+    let principalText = parts[0];
+    // check if the first part is a valid principal - will trap if not
+    // TODO: perform this check without trapping
+    let principal = Principal.fromText(principalText);
+
+    // check if the second part is "reverse"
+    if (parts[1] != "reverse") {
+      return { answers = []; additionals = []; authorities = [] };
+    };
+
+    // look up the PTR domain record of the principal
+    let answers = switch (Domain.RegistrationRecordsStore.getPtrRecord(domainRecordsStore, domain, principal)) {
+      case null { [] };
+      case (?record) { [record] };
+    };
+
+    {
+      answers;
       additionals = [];
       authorities = [];
     };

--- a/minimal_cns/canisters/tld_operator/tld_operator.test.mo
+++ b/minimal_cns/canisters/tld_operator/tld_operator.test.mo
@@ -8,7 +8,6 @@ import Result "mo:base/Result";
 import { trap } "mo:base/Runtime";
 import Text "mo:base/Text";
 import Test "../../common/test_utils";
-import ApiTypes "../../common/api_types";
 import DomainTypes "../../common/data/domain/Types";
 
 actor {
@@ -84,7 +83,7 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaaaa-aa";
+        data = "r7inp-6aaaa-aaaaa-aaabq-cai";
       };
       let registrationRecords = {
         controllers = [];
@@ -130,7 +129,7 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaaaa-aa";
+        data = "r7inp-6aaaa-aaaaa-aaabq-cai";
       };
       let registrationRecords = {
         controllers = [];
@@ -199,7 +198,7 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaaaa-aa";
+        data = "r7inp-6aaaa-aaaaa-aaabq-cai";
       };
       let registrationRecords = {
         controllers = [];
@@ -224,7 +223,7 @@ actor {
         name = record_name;
         record_type = "CID";
         ttl = 3600;
-        data = "aaaaa-aa";
+        data = "r7inp-6aaaa-aaaaa-aaabq-cai";
       };
       let registrationRecords = {
         controllers = [];
@@ -249,7 +248,7 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaaaa-aa";
+        data = "r7inp-6aaaa-aaaaa-aaabq-cai";
       };
       let registrationRecords = {
         controllers = [];
@@ -266,11 +265,11 @@ actor {
     Debug.print("    test shouldRegisterAndLookupIcpTestDomainIfNotController...");
     for (
       (domain, recordType, canisterId) in [
-        ("my_domain.test.icp.", "CID", "aaaaa-aa"),
-        ("example.test.icp.", "Cid", "em77e-bvlzu-aq"),
-        ("another.test.ICP.", "cid", "un4fu-tqaaa-aaaab-qadjq-cai"),
-        ("one.more.test.Icp.", "CId", "2vxsx-fae"),
-        ("my_domain.test.icp.", "CID", "2vxsx-fae"), // overwrite previous mapping
+        ("my_domain.test.icp.", "CID", "r7inp-6aaaa-aaaaa-aaabq-cai"),
+        ("example.test.icp.", "Cid", "rno2w-sqaaa-aaaaa-aaacq-cai"),
+        ("another.test.ICP.", "cid", "mqygn-kiaaa-aaaar-qaadq-cai"),
+        ("one.more.test.Icp.", "CId", "n5wcd-faaaa-aaaar-qaaea-cai"),
+        ("my_domain.test.icp.", "CID", "n5wcd-faaaa-aaaar-qaaea-cai"), // overwrite previous mapping
       ].vals()
     ) {
       let domainRecord : DomainRecord = {
@@ -285,7 +284,6 @@ actor {
       };
       let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
       assert Test.isTrue(registerResponse.success, asText(registerResponse.message));
-
       let lookupResponse = await IcpTldOperator.lookup(domain, recordType);
       let errMsg = "shouldRegisterAndLookupIcpTestDomainIfNotController() failed for domain: " # domain # ", recordType: " # recordType # ", size of response.";
       assert Test.isEqualInt(lookupResponse.answers.size(), 1, errMsg # "answers");
@@ -304,9 +302,9 @@ actor {
     // The test data is a subset from shouldRegisterAndLookupIcpTestDomainIfNotController()
     for (
       (domain, recordType, canisterId) in [
-        ("example.test.icp.", "Cid", "em77e-bvlzu-aq"),
-        ("another.test.ICP.", "cid", "un4fu-tqaaa-aaaab-qadjq-cai"),
-        ("one.more.test.Icp.", "CId", "2vxsx-fae"),
+        ("example.test.icp.", "Cid", "rno2w-sqaaa-aaaaa-aaacq-cai"),
+        ("another.test.ICP.", "cid", "mqygn-kiaaa-aaaar-qaadq-cai"),
+        ("one.more.test.Icp.", "CId", "n5wcd-faaaa-aaaar-qaaea-cai"),
       ].vals()
     ) {
       let expectedDomainRecord : DomainRecord = {
@@ -319,7 +317,7 @@ actor {
         name = domain;
         record_type = "CID";
         ttl = 3600;
-        data = "aaaaa-aa"; // try to override an existing mapping
+        data = "r7inp-6aaaa-aaaaa-aaabq-cai"; // try to override an existing mapping
       };
       let registrationRecords = {
         controllers = [];
@@ -343,7 +341,7 @@ actor {
   func shouldRegisterTestDomainOtherCallerRegistrant() : async () {
     Debug.print("    test shouldRegisterTestDomainOtherCallerRegistrant...");
     let domain = "to-be-overriden.test.icp.";
-    let canisterId = "2vxsx-fae";
+    let canisterId = "n5wcd-faaaa-aaaar-qaaea-cai";
     let record : DomainRecord = {
       name = domain;
       record_type = "CID";
@@ -361,7 +359,7 @@ actor {
   func shouldOverwriteTestDomainIfController() : async () {
     Debug.print("    test shouldOverwriteTestDomainIfController...");
     let domain = "to-be-overriden.test.icp.";
-    let canisterId = "2vxsx-fae";
+    let canisterId = "n5wcd-faaaa-aaaar-qaaea-cai";
     let expectedDomainRecord : DomainRecord = {
       name = domain;
       record_type = "CID";
@@ -384,7 +382,7 @@ actor {
       name = domain;
       record_type = "CID";
       ttl = 600; // different ttl
-      data = "aaaaa-aa"; // different canister id
+      data = "r7inp-6aaaa-aaaaa-aaabq-cai"; // different canister id
     };
     let registrationRecords = {
       controllers = [];
@@ -433,7 +431,7 @@ actor {
       name = domain;
       record_type = "NS";
       ttl = 3600;
-      data = "aaaaa-aa";
+      data = "r7inp-6aaaa-aaaaa-aaabq-cai";
     };
     let registrationRecords = {
       controllers = [];
@@ -441,7 +439,7 @@ actor {
     };
     let registerResponse = await IcpTldOperator.register(domain, registrationRecords);
     assert Test.isFalse(registerResponse.success, "Registration of " # domain # " succeeded unexpectedly");
-    assert Test.textContains(asText(registerResponse.message), "only CID-records can be registered", "Registration of " # domain # " failed for a wrong reason");
+    assert Test.textContains(asText(registerResponse.message), "only CID and SID records can be registered", "Registration of " # domain # " failed for a wrong reason");
   };
 
   func shouldNotRegisterTestDomainIfExplicitController() : async () {
@@ -451,11 +449,11 @@ actor {
       name = domain;
       record_type = "CID";
       ttl = 3600;
-      data = "aaaaa-aa";
+      data = "r7inp-6aaaa-aaaaa-aaabq-cai";
     };
     let registrationRecords : DomainTypes.RegistrationRecords = {
       controllers = [{
-        principal = Principal.fromText("aaaaa-aa");
+        principal = Principal.fromText("r7inp-6aaaa-aaaaa-aaabq-cai");
         roles : [DomainTypes.RegistrationControllerRole] = [#registrant];
       }];
       records = ?[record];
@@ -472,7 +470,7 @@ actor {
       name = "other.domain.test.icp.";
       record_type = "CID";
       ttl = 3600;
-      data = "aaaaa-aa";
+      data = "r7inp-6aaaa-aaaaa-aaabq-cai";
     };
     let registrationRecords = {
       controllers = [];
@@ -490,7 +488,7 @@ actor {
       name = domain;
       record_type = "CID";
       ttl = 3600;
-      data = "aaaaa-aa";
+      data = "r7inp-6aaaa-aaaaa-aaabq-cai";
     };
     let registrationRecords = {
       controllers = [];
@@ -529,7 +527,7 @@ actor {
       name = "example.icp.";
       record_type = "CID";
       ttl = 3600;
-      data = "aaaaa-aa";
+      data = "r7inp-6aaaa-aaaaa-aaabq-cai";
     };
     let registrationRecords = {
       controllers = [];

--- a/minimal_cns/common/data/domain/Types.mo
+++ b/minimal_cns/common/data/domain/Types.mo
@@ -46,19 +46,17 @@ module {
     roles : [RegistrationControllerRole];
   };
 
+  public type NewRegistrationDomainRecord = {
+    controllers : [RegistrationController];
+    record : DomainRecord;
+  };
+
   public type RegistrationRecords = {
     controllers : [RegistrationController];
     records : ?[DomainRecord];
   };
 
-  public type RegistrationRecordsWithPrincipals = {
-    // The registration records for a domain.
-    records : RegistrationRecords;
-    // The list of principals that point to that domain.
-    principals : StableBuffer.StableBuffer<Principal>;
-  };
-
-  public type RegistrationRecordsMap = Map.Map<Domain, RegistrationRecordsWithPrincipals>;
+  public type RegistrationRecordsMap = Map.Map<Domain, RegistrationRecords>;
   public type PrincipalToDomainIndex = Map.Map<Principal, Domain>;
 
   public type RegistrationRecordsStore = {

--- a/minimal_cns/common/data/domain/lib.mo
+++ b/minimal_cns/common/data/domain/lib.mo
@@ -3,7 +3,6 @@ import Array "mo:base/Array";
 import Map "mo:base/Map";
 import Text "mo:base/Text";
 import Principal "mo:base/Principal";
-import StableBuffer "mo:stable-buffer/StableBuffer";
 
 module {
   public module DomainRecordsStore {

--- a/minimal_cns/common/data/domain/lib.mo
+++ b/minimal_cns/common/data/domain/lib.mo
@@ -1,6 +1,8 @@
 import Types "Types";
+import Array "mo:base/Array";
 import Map "mo:base/Map";
 import Text "mo:base/Text";
+import Principal "mo:base/Principal";
 import StableBuffer "mo:stable-buffer/StableBuffer";
 
 module {
@@ -32,7 +34,7 @@ module {
   public module RegistrationRecordsStore {
     public func init() : Types.RegistrationRecordsStore {
       {
-        domainToRecordsMap = Map.empty<Types.Domain, Types.RegistrationRecordsWithPrincipals>();
+        domainToRecordsMap = Map.empty<Types.Domain, Types.RegistrationRecords>();
         principalToDomainIndex = Map.empty<Principal, Types.Domain>();
       };
     };
@@ -44,30 +46,113 @@ module {
     public func getByDomain(
       store : Types.RegistrationRecordsStore,
       domain : Types.Domain,
-    ) : ?Types.RegistrationRecordsWithPrincipals {
+    ) : ?Types.RegistrationRecords {
       Map.get(store.domainToRecordsMap, Text.compare, domain);
     };
 
-    // TODO: Drop in replacement - improve this in the next PR
+    public func getByDomainAndRecordType(
+      store : Types.RegistrationRecordsStore,
+      domain : Types.Domain,
+      recordType : Text,
+    ) : ?Types.DomainRecord {
+      let maybeRegistrationRecords = switch (getByDomain(store, domain)) {
+        case null { return null };
+        case (?registrationRecords) { registrationRecords.records };
+      };
+      let recordsList = switch (maybeRegistrationRecords) {
+        case null { return null };
+        case (?records) { records };
+      };
+
+      Array.find<Types.DomainRecord>(
+        recordsList,
+        func(record) { record.record_type == recordType },
+      );
+    };
+
+    // Synthesizes a PTR record for a given principal by looking up the domain for that principal
+    // in the principal to domain index, and then ensuring that a domain record for that domain exists
+    public func getPtrRecord(
+      store : Types.RegistrationRecordsStore,
+      reverseDomain : Text,
+      principal : Principal,
+    ) : ?Types.DomainRecord {
+      let domain = switch (Map.get(store.principalToDomainIndex, Principal.compare, principal)) {
+        case null { return null };
+        case (?domain) { domain };
+      };
+      // Attempt to retrieve the domain record for the reverse index (sanity check + inherits the same ttl).
+      let domainRecord = switch (getByDomain(store, domain)) {
+        case null { return null };
+        case (?maybeRegistrationRecords) {
+          switch (maybeRegistrationRecords.records) {
+            case null { return null };
+            case (?records) { records[0] };
+          };
+        };
+      };
+
+      return ?{
+        name = reverseDomain;
+        record_type = "PTR";
+        ttl = domainRecord.ttl;
+        data = domain; // The PTR record points to the domain name
+      };
+    };
+
+    // TODO: Handle the case where there are more than one record type per domain (doesn't just overwrite the existing registration records)
     public func add(
       store : Types.RegistrationRecordsStore,
       domain : Types.Domain,
-      records : Types.RegistrationRecords,
-      principals : [Principal],
+      { controllers; record } : Types.NewRegistrationDomainRecord,
     ) : () {
+      // if this is a principal record type CID or SID (in the future maybe other principals?),
+      // update the principal to domain index
+      if (isPrincipalRecordType(record.record_type)) {
+        // update the principal to domain index entry (add new or update existing)
+        updatePrincipalToDomainIndexEntry(store, domain, record);
+      };
+
+      let registrationRecords : Types.RegistrationRecords = {
+        controllers;
+        records = ?[record];
+      };
+
       Map.add(
         store.domainToRecordsMap,
         Text.compare,
         domain,
-        {
-          records;
-          principals = StableBuffer.fromArray<Principal>(principals);
-        },
+        registrationRecords,
       );
+    };
 
-      // TODOs (next PR):
-      // 1. Update the list of principals associated with the domain
-      // 2. Update principal to domain index
+    func updatePrincipalToDomainIndexEntry(
+      store : Types.RegistrationRecordsStore,
+      domain : Types.Domain,
+      newRecord : Types.DomainRecord,
+    ) : () {
+      // TODO: don't trap on invalid Principals.
+      let newPrincipalData = Principal.fromText(newRecord.data);
+      switch (
+        getByDomainAndRecordType(
+          store,
+          domain,
+          newRecord.record_type,
+        )
+      ) {
+        case null {};
+        case (?existingRecord) {
+          // TODO: don't trap on invalid Principals.
+          let oldPrincipalData = Principal.fromText(existingRecord.data);
+          // If the old principal data is different, first remove the old principal to domain entry from the index
+          if (oldPrincipalData != newPrincipalData) {
+            Map.remove(store.principalToDomainIndex, Principal.compare, oldPrincipalData);
+          };
+        };
+      };
+
+      // Add the new principal to domain index entry
+      Map.add(store.principalToDomainIndex, Principal.compare, newPrincipalData, domain);
     };
   };
 
@@ -78,5 +163,12 @@ module {
       ttl = record.ttl;
       data = record.data;
     };
+  };
+
+  func isPrincipalRecordType(recordType : Text) : Bool {
+    Array.any<Text>(
+      ["CID", "SID"],
+      func(supportedType) { supportedType == recordType },
+    );
   };
 };


### PR DESCRIPTION
* Refactor: Remove data structure support for multiple principals (i.e. CIDs) pointing to the same domain
* Feat: Added subnet "SID" record types
* Feat: Added implied reverse "PTR" record lookups for both "CID" and "SID" records
* Feat: Added SID record validation
* Feat: Added some CID record validation
* Fix: Now that registering CID records has Canister ID validation, replace invalid canister principals in tests with actual canister ids.
* Test: Added brief unit tests covering SID creation, and that SID and CID records can be looked up by their PTR reverse domain.