### PR TITLE
fix: disable creation of PTR-records for test-domains

### DIFF
--- a/lib/ic-cns-canister-client/rs/tests/register_and_lookup.rs
+++ b/lib/ic-cns-canister-client/rs/tests/register_and_lookup.rs
@@ -265,6 +265,6 @@ fn should_register_test_domains_if_not_controller() {
         let result = env.lookup_domain(domain);
         assert_matches!(result, Ok(cid) if (cid.to_string() == cid_text));
         let result = env.domain_for_canister(cid_text);
-        assert_matches!(result, Ok(d) if (domain == d));
+        assert_matches!(result, Err(err) if (err.to_string().contains("No domain found for canister")));
     }
 }

--- a/minimal_cns/README.md
+++ b/minimal_cns/README.md
@@ -26,7 +26,7 @@ Currently, the following components are being worked on:
   - `lookup`-operation, available publicly, returning CID- or SID- records for `.icp`-domains,
     provided previously via `register`-operation.
   - `lookup`-operation for reverse lookup by principal (canister id or subnet id), returning `PTR`-like
-    records if a domain has been assigned to the principal previously
+    records if a **non-test domain** has been assigned to the principal previously
     (cf. [here](https://en.wikipedia.org/wiki/List_of_DNS_record_types#PTR)).  
     To make a reverse lookup for a principal, encode the principal in a special domain
     `<text representation of principal>.reverse.icp.` and request `PTR`-record.

--- a/minimal_cns/canisters/tld_operator/mutations.mo
+++ b/minimal_cns/canisters/tld_operator/mutations.mo
@@ -49,7 +49,8 @@ module {
       record = domainRecord;
     };
 
-    Domain.RegistrationRecordsStore.add(lookupAnswersMap, domainLowercase, newRegistrationRecord);
+    let updatePtrRecords = not Text.endsWith(domainLowercase, #text(".test" # myTld));
+    Domain.RegistrationRecordsStore.add(lookupAnswersMap, domainLowercase, newRegistrationRecord, updatePtrRecords);
 
     (
       {

--- a/minimal_cns/common/data/domain/lib.mo
+++ b/minimal_cns/common/data/domain/lib.mo
@@ -104,10 +104,11 @@ module {
       store : Types.RegistrationRecordsStore,
       domain : Types.Domain,
       { controllers; record } : Types.NewRegistrationDomainRecord,
+      updatePtrRecords : Bool,
     ) : () {
       // if this is a principal record type CID or SID (in the future maybe other principals?),
       // update the principal to domain index
-      if (isPrincipalRecordType(record.record_type)) {
+      if (updatePtrRecords and isPrincipalRecordType(record.record_type)) {
         // update the principal to domain index entry (add new or update existing)
         updatePrincipalToDomainIndexEntry(store, domain, record);
       };


### PR DESCRIPTION
As reverse lookups should return some "canonical" PTR record(s), it is dependent on a policy on how to decide what "canonical" means.  To avoid conflicts with registration of `.test.icp.` domains, this PR temporarily disables creation of PTR-records for `test`-domains.